### PR TITLE
fix(#37): empty list in struct-array first row no longer corrupts unification

### DIFF
--- a/src/yaml_reader_types.cpp
+++ b/src/yaml_reader_types.cpp
@@ -406,13 +406,25 @@ Value YAMLReader::YAMLNodeToValue(const YAML::Node &node, const LogicalType &tar
 	case YAML::NodeType::Sequence: {
 		if (target_type.id() != LogicalTypeId::LIST) {
 			return Value(target_type); // NULL if not expecting a list
-		} else if (node.size() == 0) {
-			// Empty lists need an explicit type (ISSUE #8)
-			return Value::LIST(target_type, {});
 		}
-
-		// Get child type for list
+		// Get child type for list (used by both the empty-list and non-empty branches).
 		auto child_type = ListType::GetChildType(target_type);
+		if (node.size() == 0) {
+			// Empty lists need an explicit element type — pass the CHILD type, not
+			// `target_type` (which is the whole LIST<child>). Previously this passed
+			// `target_type`, producing a Value with type LIST<LIST<child>> that
+			// poisoned outer struct unification (issue #37) when the first row of a
+			// struct-array field had an empty list and a later row had data:
+			//
+			//   data_models: []                  -> LIST<LIST<VARCHAR>>  (bug)
+			//   data_models: [OVR-DM-001]        -> LIST<VARCHAR>        (correct)
+			//
+			// Unification then tried to cast the second row's VARCHAR element to
+			// LIST<VARCHAR> and failed with the misleading "Failed to cast value:
+			// Type VARCHAR ... can't be cast to the destination type VARCHAR[]"
+			// error from the bug report. The fix is to use child_type uniformly.
+			return Value::LIST(child_type, {});
+		}
 
 		// Create list of values - recursively convert each element
 		vector<Value> values;

--- a/test/sql/yaml_reader/yaml_issue_37_empty_list_nesting.test
+++ b/test/sql/yaml_reader/yaml_issue_37_empty_list_nesting.test
@@ -1,0 +1,48 @@
+# name: test/sql/yaml_reader/yaml_issue_37_empty_list_nesting.test
+# description: Regression for issue #37 — empty list in the FIRST row of a struct-array
+#              field used to be inferred as LIST<LIST<child>> instead of LIST<child>,
+#              causing later rows with populated lists to fail unification with a
+#              misleading "Failed to cast value: Type VARCHAR ... can't be cast to
+#              the destination type VARCHAR[]" error in YAMLNodeToValue's
+#              empty-Sequence branch.
+# group: [yaml_reader]
+
+require yaml
+
+# ============================================================================
+# Repro: empty list first, populated list later  (the failing case in #37)
+# ============================================================================
+# Before the fix, this SELECT failed with a misleading cast error even though
+# DESCRIBE showed the right type. After the fix the SELECT just works.
+
+query II
+SELECT s.id, s.data_models
+FROM (SELECT unnest(specifications) AS s FROM read_yaml('test/yaml/issue_37_empty_first.yaml'))
+ORDER BY s.id;
+----
+A	[]
+B	[OVR-DM-001]
+
+# Sanity-check that the inferred element type is exactly VARCHAR[] (not
+# LIST<LIST<VARCHAR>> as the bug produced). If the bug recurs, the materialised
+# value for row B's data_models would surface here as the doubly-nested shape.
+query I
+SELECT len(s.data_models)
+FROM (SELECT unnest(specifications) AS s FROM read_yaml('test/yaml/issue_37_empty_first.yaml'))
+WHERE s.id = 'B';
+----
+1
+
+# ============================================================================
+# Control: populated list first, empty list later  (worked before the fix too)
+# ============================================================================
+# Keep this as a regression net for the other direction — if a future change
+# breaks the originally-working ordering, this catches it.
+
+query II
+SELECT s.id, s.data_models
+FROM (SELECT unnest(specifications) AS s FROM read_yaml('test/yaml/issue_37_populated_first.yaml'))
+ORDER BY s.id;
+----
+A	[OVR-DM-001]
+B	[]

--- a/test/yaml/issue_37_empty_first.yaml
+++ b/test/yaml/issue_37_empty_first.yaml
@@ -1,0 +1,5 @@
+specifications:
+  - id: A
+    data_models: []
+  - id: B
+    data_models: [OVR-DM-001]

--- a/test/yaml/issue_37_populated_first.yaml
+++ b/test/yaml/issue_37_populated_first.yaml
@@ -1,0 +1,5 @@
+specifications:
+  - id: A
+    data_models: [OVR-DM-001]
+  - id: B
+    data_models: []


### PR DESCRIPTION
Closes #37.

## TL;DR

`YAMLNodeToValue`'s empty-Sequence branch was calling `Value::LIST(target_type, {})` where `target_type` is the WHOLE list type (e.g., `LIST<VARCHAR>`). `Value::LIST(child_type, values)` expects the **element** type as its first argument. The bug produced an empty value with type `LIST<LIST<VARCHAR>>` instead of `LIST<VARCHAR>` — silently corrupting struct-array unification when the first row had an empty list and a later row had data.

## The fix

One line. Hoist `auto child_type = ListType::GetChildType(target_type)` out of the non-empty branch so the empty branch can use it too:

```diff
 case YAML::NodeType::Sequence: {
     if (target_type.id() != LogicalTypeId::LIST) {
         return Value(target_type); // NULL if not expecting a list
-    } else if (node.size() == 0) {
-        // Empty lists need an explicit type (ISSUE #8)
-        return Value::LIST(target_type, {});
     }
-
-    // Get child type for list
     auto child_type = ListType::GetChildType(target_type);
+    if (node.size() == 0) {
+        return Value::LIST(child_type, {});  // pass child, not target
+    }
```

The non-empty branch was already using `child_type` correctly — so this is just bringing the empty branch in line with how the rest of the function works.

## Regression test

New `test/sql/yaml_reader/yaml_issue_37_empty_list_nesting.test` reproduces the exact case from #37:

```yaml
specifications:
  - id: A
    data_models: []                    # empty FIRST
  - id: B
    data_models: [OVR-DM-001]           # populated later
```

Before this fix: `SELECT *` failed with the bug report's `Failed to cast value: Type VARCHAR ... can't be cast to the destination type VARCHAR[]` error. After: works as expected. Test also includes the populated-first control case so a regression in either direction is visible.

## Notes for users on the workaround

The bug report documents a workaround using `columns={'specifications': 'yaml'}` + `json_transform` to bypass `YAMLNodeToValue`. With this fix landed (and a new patch release tagged), that workaround can be retired — `read_yaml` will materialise the natural struct-array type directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)