### PR TITLE
fix(wasm): link yaml-cpp via LINKED_LIBS so the WASM build loads (#40)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -66,12 +66,13 @@ jobs:
         run: bash test/wasm/run_wasm_checks.sh wasm-artifacts
       - name: Live load test in duckdb-wasm (informational until official v1.5.3)
         continue-on-error: true
+        timeout-minutes: 10
         working-directory: test/wasm
         run: |
-          set -euo pipefail
-          npm install --no-save
+          set -uo pipefail
+          timeout 300 npm install --no-save
           mkdir -p repo/v1.5.3/wasm_eh
           cp "$GITHUB_WORKSPACE/wasm-artifacts/yaml-v1.5.3-extension-wasm_eh/yaml.duckdb_extension.wasm" \
              repo/v1.5.3/wasm_eh/
-          node load_test.cjs --repo repo --name yaml --platform eh \
+          timeout 240 node load_test.cjs --repo repo --name yaml --platform eh \
             --query "SELECT yaml_valid('a: 1') AS ok" --expect '"ok":true'

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -42,11 +42,14 @@ jobs:
   # Guards against the LINKED_LIBS class of WASM bug (issue #40): the reusable
   # distribution workflow builds and uploads the .wasm but never inspects or
   # loads it, so a side module with unresolved yaml-cpp symbols ships green.
-  # This downloads the built v1.5.3 wasm artifacts and statically checks that no
-  # yaml-cpp symbol is imported-but-undefined (no duckdb-wasm runtime needed).
-  # See test/wasm/ for the full explanation.
-  wasm-symbol-check:
-    name: WASM symbol resolution check
+  # Two layers (see test/wasm/):
+  #   1. static symbol check (hard gate) — no duckdb-wasm runtime needed.
+  #   2. live load+query in duckdb-wasm (informational / continue-on-error) —
+  #      expected-red until official duckdb-wasm ships v1.5.3 (the only public
+  #      v1.5.3 engine, haybarn, is built v1.5.4-dev with a newer emscripten,
+  #      so a v1.5.3 extension hits a duckdb/emscripten ABI skew on LOAD).
+  wasm-load-test:
+    name: WASM load test
     needs: [duckdb-stable-build]
     runs-on: ubuntu-latest
     steps:
@@ -59,5 +62,16 @@ jobs:
         with:
           pattern: yaml-v1.5.3-extension-wasm_*
           path: wasm-artifacts
-      - name: Check for unresolved yaml-cpp symbols
+      - name: Static symbol check (yaml-cpp must be linked, not unresolved)
         run: bash test/wasm/run_wasm_checks.sh wasm-artifacts
+      - name: Live load test in duckdb-wasm (informational until official v1.5.3)
+        continue-on-error: true
+        working-directory: test/wasm
+        run: |
+          set -euo pipefail
+          npm install --no-save
+          mkdir -p repo/v1.5.3/wasm_eh
+          cp "$GITHUB_WORKSPACE/wasm-artifacts/yaml-v1.5.3-extension-wasm_eh/yaml.duckdb_extension.wasm" \
+             repo/v1.5.3/wasm_eh/
+          node load_test.cjs --repo repo --name yaml --platform eh \
+            --query "SELECT yaml_valid('a: 1') AS ok" --expect '"ok":true'

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -38,3 +38,26 @@ jobs:
       ci_tools_version: main
       extension_name: yaml
       format_checks: 'format'
+
+  # Guards against the LINKED_LIBS class of WASM bug (issue #40): the reusable
+  # distribution workflow builds and uploads the .wasm but never inspects or
+  # loads it, so a side module with unresolved yaml-cpp symbols ships green.
+  # This downloads the built v1.5.3 wasm artifacts and statically checks that no
+  # yaml-cpp symbol is imported-but-undefined (no duckdb-wasm runtime needed).
+  # See test/wasm/ for the full explanation.
+  wasm-symbol-check:
+    name: WASM symbol resolution check
+    needs: [duckdb-stable-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: yaml-v1.5.3-extension-wasm_*
+          path: wasm-artifacts
+      - name: Check for unresolved yaml-cpp symbols
+        run: bash test/wasm/run_wasm_checks.sh wasm-artifacts

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -4,6 +4,12 @@
 duckdb_extension_load(yaml
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
+    # WASM side modules are linked by a separate `emcc -sSIDE_MODULE=2 ...
+    # ${LINKED_LIBS}` step (see duckdb/extension/extension_build_tools.cmake)
+    # that ignores target_link_libraries(). Without naming yaml-cpp here its
+    # symbols are left as unresolved imports and the .wasm fails to load /
+    # throws at first call. See test/wasm/ and issue #40.
+    LINKED_LIBS "$<TARGET_FILE:yaml-cpp::yaml-cpp>"
 )
 
 # Any extra extensions that should be built

--- a/test/wasm/README.md
+++ b/test/wasm/README.md
@@ -1,0 +1,90 @@
+# WASM build tests
+
+These tests guard against the failure mode reported in
+[#40](https://github.com/teaguesterling/duckdb_yaml/issues/40): the DuckDB-WASM
+build installs but fails to load (or fails at first function call) because a
+dependency's symbols are left unresolved in the side module.
+
+## Root cause
+
+The loadable `*.duckdb_extension.wasm` is **not** produced by the normal CMake
+link. DuckDB's `extension/extension_build_tools.cmake` runs a separate
+`emcc -sSIDE_MODULE=2 ... ${LINKED_LIBS}` post-build step. That step links the
+extension object archive against **only** the libraries named in
+`LINKED_LIBS` in `extension_config.cmake`. The `target_link_libraries(...)`
+calls in `CMakeLists.txt` are honored for native builds but **ignored** by this
+emcc step. If `yaml-cpp` is not in `LINKED_LIBS`, its symbols become unresolved
+`env` imports in the `.wasm`.
+
+The fix is in `extension_config.cmake`:
+
+```cmake
+duckdb_extension_load(yaml
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
+    LOAD_TESTS
+    LINKED_LIBS "$<TARGET_FILE:yaml-cpp::yaml-cpp>"
+)
+```
+
+## Two layers of testing
+
+### Layer 1 — static import check (fast, deterministic, no runtime)
+
+`check_wasm_imports.mjs` parses the built `.wasm` (validate-only, **no
+instantiation**) and fails if any dependency symbol is **imported but not also
+defined/exported** by the module.
+
+Subtlety that matters: emscripten side modules use interposition linking, so a
+module legitimately *imports* many symbols it also *defines* (and legitimately
+imports host-provided symbols — duckdb's runtime, and core deps like yyjson
+that are bundled into the duckdb-wasm host). So "is it imported" is the **wrong**
+question and produces false positives. The real bug is a dependency symbol that
+is imported, **not** in the module's own exports, and not host-provided — i.e.
+genuinely unresolved. Imports are resolved per bucket against the right export
+kind: `env`/`GOT.func` → exported functions, `GOT.mem` → exported data globals
+(so unresolved **vtables** `_ZTV*` / typeinfo `_ZTI*` are caught too, not just
+functions). Empirically: a broken yaml build has 38 such unresolved symbols
+(29 `env` functions like `YAML::Load`/`YAML::Emitter::*`/`YAML::detail::node_data::*`,
+plus `GOT.func`/`GOT.mem` entries incl. `_ZTVN4YAML9ExceptionE`); the fixed
+build has 0 across all kinds.
+
+Why static, not instantiation-based:
+- It catches the bug whether the missing symbol would fail at **load** time or
+  only at **call** time (DuckDB-WASM side modules can load "successfully" and
+  then throw on the first call that needs the symbol — see Rusty Conover's
+  writeup below).
+- It needs **no** matching `@duckdb/duckdb-wasm` engine and **no** duckdb
+  version match, so a red result is unambiguously the LINKED_LIBS bug and not an
+  ABI/version mismatch.
+
+Run after a wasm build:
+
+```bash
+make wasm_mvp                       # or wasm_eh / wasm_threads
+test/wasm/run_wasm_checks.sh        # scans build/wasm_* for *.wasm
+```
+
+Exit non-zero = forbidden dependency symbols found.
+
+### Layer 2 — end-to-end sqllogictest against duckdb-wasm (high fidelity)
+
+Rusty Conover's harness instantiates the published WASM engine in Node, does
+`INSTALL ... FROM community; LOAD ...`, and runs the extension's existing
+`test/sql/*.test` files against it. This validates that the extension actually
+*works* under wasm (not just that symbols resolve), and also surfaces
+version/ABI problems. It requires a published artifact + matching engine.
+
+- Harness: https://github.com/Query-farm-haybarn/haybarn-extension-wasm-tester
+- Writeup: https://rusty.today/blog/testing-duckdb-wasm-extensions/
+
+Layer 1 is the build-time gate (runs on the artifact we just built); Layer 2 is
+the post-publish / pre-release end-to-end check.
+
+## CI
+
+`make wasm_mvp` etc. run inside the reusable
+`duckdb/extension-ci-tools` distribution workflow, which currently **builds and
+uploads** the `.wasm` but never inspects or loads it — which is why this bug
+shipped. The plan is to add Layer 1 as a step right after the wasm build (it
+only needs `node`), and to propose the same generic step upstream so every
+extension benefits.

--- a/test/wasm/README.md
+++ b/test/wasm/README.md
@@ -66,19 +66,36 @@ test/wasm/run_wasm_checks.sh        # scans build/wasm_* for *.wasm
 
 Exit non-zero = forbidden dependency symbols found.
 
-### Layer 2 — end-to-end sqllogictest against duckdb-wasm (high fidelity)
+### Layer 2 — live load test in duckdb-wasm (`load_test.cjs`)
 
-Rusty Conover's harness instantiates the published WASM engine in Node, does
-`INSTALL ... FROM community; LOAD ...`, and runs the extension's existing
-`test/sql/*.test` files against it. This validates that the extension actually
-*works* under wasm (not just that symbols resolve), and also surfaces
-version/ABI problems. It requires a published artifact + matching engine.
+`load_test.cjs` instantiates a duckdb-wasm engine in Node, serves the built
+extension repository over HTTP, `INSTALL`s + `LOAD`s the extension, and runs a
+query (`SELECT yaml_valid('a: 1')`). End-to-end proof that the module not only
+resolves symbols but instantiates and runs. Needs the npm deps in `package.json`.
 
-- Harness: https://github.com/Query-farm-haybarn/haybarn-extension-wasm-tester
-- Writeup: https://rusty.today/blog/testing-duckdb-wasm-extensions/
+```bash
+make wasm_eh
+cd test/wasm && npm install
+mkdir -p repo/v1.5.3/wasm_eh
+cp ../../build/wasm_eh/repository/v1.5.3/wasm_eh/yaml.duckdb_extension.wasm repo/v1.5.3/wasm_eh/
+node load_test.cjs --repo repo --name yaml --platform eh \
+    --query "SELECT yaml_valid('a: 1') AS ok" --expect '"ok":true'
+```
 
-Layer 1 is the build-time gate (runs on the artifact we just built); Layer 2 is
-the post-publish / pre-release end-to-end check.
+**Engine matching (important).** A clean `LOAD` needs an engine matching **both**
+the extension's duckdb version (v1.5.3) **and** its emscripten ABI
+(`extension-ci-tools@v1.5.3` pins emsdk 3.1.71). As of this writing no public
+engine satisfies both: `@duckdb/duckdb-wasm` is still v1.5.1 (→ version skew),
+and `@haybarn/haybarn-wasm` 1.5.3-rc15 is built v1.5.4-dev with a newer
+emscripten (→ duckdb/emscripten ABI skew on LOAD, e.g. a
+`TemplatedValidityMask::Copy` / `lseek` import type mismatch). In both engines
+the load gets **past symbol resolution** (no missing/undefined symbol) —
+confirming the LINKED_LIBS fix — and fails only on version/toolchain ABI. The
+live test goes green once official duckdb-wasm ships v1.5.3; until then it is a
+**non-blocking** CI step and the Layer 1 static check is the hard gate.
+
+Background: https://rusty.today/blog/testing-duckdb-wasm-extensions/ ·
+https://github.com/Query-farm-haybarn/haybarn-extension-wasm-tester
 
 ## CI
 

--- a/test/wasm/check_wasm_imports.mjs
+++ b/test/wasm/check_wasm_imports.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// WASM side-module unresolved-dependency-symbol check.
+//
+// Why this exists: the loadable `.duckdb_extension.wasm` is produced by a
+// separate `emcc -sSIDE_MODULE=2 ... ${LINKED_LIBS}` step (see duckdb's
+// extension/extension_build_tools.cmake). That link ONLY pulls in libraries
+// named in `LINKED_LIBS` in extension_config.cmake -- `target_link_libraries`
+// in CMakeLists.txt is ignored for it. If a dependency (yaml-cpp here, LibXml2
+// for webbed) is not in LINKED_LIBS, its symbols end up imported by the module
+// but defined nowhere; since the duckdb-wasm host does not provide them the
+// module fails to load ("could not load dynamic lib") or throws at first call.
+// CI builds the .wasm but never inspects it, so this ships green.
+//
+// What it checks -- and why "is it imported" is the WRONG question:
+// emscripten side modules use position-independent / interposition linking, so
+// a module legitimately IMPORTS many symbols it also DEFINES/EXPORTS, and also
+// imports host-provided symbols (duckdb's C++ runtime; core deps bundled into
+// the duckdb-wasm host such as yyjson). The genuine bug is a dependency symbol
+// that is imported, NOT defined by this module, and not host-provided -- i.e.
+// genuinely unresolved.
+//
+// Imports come in three relevant buckets and must be resolved against the
+// right export kind (functions vs data globals):
+//   - module "env",      kind function  -> direct call          -> exported fn
+//   - module "GOT.func", kind global    -> function address slot -> exported fn
+//   - module "GOT.mem",  kind global    -> data address slot     -> exported global
+// A GOT.mem entry is how data symbols (vtables _ZTV*, typeinfo _ZTI*) are
+// referenced, so checking only function imports would miss an unresolved
+// vtable that breaks loading just like a missing function.
+//
+// Static parse only (WebAssembly.Module) -- no instantiation, no duckdb-wasm
+// runtime, no duckdb version match -- so a failure is unambiguously the
+// LINKED_LIBS bug and not an ABI/version mismatch.
+//
+// Usage:
+//   node check_wasm_imports.mjs <path-to.wasm> --forbid <regex> [--forbid <regex> ...] [--verbose]
+//
+// Exit: 0 = clean, 1 = unresolved dependency symbols found, 2 = usage/file error.
+
+import { readFileSync } from "node:fs";
+
+const argv = process.argv.slice(2);
+const forbid = [];
+let wasmPath = null;
+let verbose = false;
+
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "--forbid") forbid.push(new RegExp(argv[++i]));
+  else if (a === "--verbose" || a === "-v") verbose = true;
+  else if (!wasmPath) wasmPath = a;
+  else { console.error(`unexpected argument: ${a}`); process.exit(2); }
+}
+
+if (!wasmPath || forbid.length === 0) {
+  console.error("usage: node check_wasm_imports.mjs <path-to.wasm> --forbid <regex> [--forbid <regex> ...] [--verbose]");
+  process.exit(2);
+}
+
+let bytes;
+try { bytes = readFileSync(wasmPath); }
+catch (e) { console.error(`cannot read ${wasmPath}: ${e.message}`); process.exit(2); }
+
+let mod;
+try { mod = new WebAssembly.Module(bytes); }
+catch (e) { console.error(`not a valid wasm module: ${e.message}`); process.exit(2); }
+
+const matches = (name) => forbid.some((re) => re.test(name));
+
+const imports = WebAssembly.Module.imports(mod);
+const exports = WebAssembly.Module.exports(mod);
+const expFn = new Set(exports.filter((e) => e.kind === "function").map((e) => e.name));
+const expGl = new Set(exports.filter((e) => e.kind === "global").map((e) => e.name));
+
+// Does this module itself satisfy the import? (interposition self-resolution)
+function selfResolved(imp) {
+  if (imp.kind === "function") return expFn.has(imp.name);     // env.<fn>
+  if (imp.module === "GOT.func") return expFn.has(imp.name);   // function address
+  if (imp.module === "GOT.mem") return expGl.has(imp.name) || expFn.has(imp.name); // data address
+  if (imp.kind === "global") return expGl.has(imp.name);       // env global / data
+  return false; // tables/memories etc. are host-provided runtime, never dep symbols
+}
+
+const depImports = imports.filter((i) => matches(i.name));
+const unresolved = depImports.filter((i) => !selfResolved(i));
+
+if (verbose) {
+  const byBucket = {};
+  for (const u of unresolved) byBucket[u.module] = (byBucket[u.module] || 0) + 1;
+  console.error(`[check] ${wasmPath}`);
+  console.error(`  imports: ${imports.length} | exports: ${expFn.size} fn, ${expGl.size} global`);
+  console.error(`  dependency-matching imports: ${depImports.length} | unresolved: ${unresolved.length} ${JSON.stringify(byBucket)}`);
+}
+
+if (unresolved.length > 0) {
+  console.error(`FAIL: ${unresolved.length} unresolved dependency symbol(s) in ${wasmPath} (imported, not defined by the module, not host-provided). The dependency is missing from LINKED_LIBS:`);
+  for (const o of unresolved.slice(0, 40)) console.error(`  ${o.module}.${o.name}`);
+  if (unresolved.length > 40) console.error(`  ... and ${unresolved.length - 40} more`);
+  process.exit(1);
+}
+
+console.error(`PASS: ${wasmPath} -- ${depImports.length} dependency import(s) all resolved by the module, 0 unresolved (${imports.length} imports inspected).`);
+process.exit(0);

--- a/test/wasm/load_test.cjs
+++ b/test/wasm/load_test.cjs
@@ -1,0 +1,69 @@
+// duckdb-wasm load test: actually LOAD a locally-built extension .wasm into a
+// version-matched duckdb-wasm engine and run a query. End-to-end counterpart to
+// the static check_wasm_imports.mjs gate. Uses the ASYNC API (the blocking API
+// deadlocks on LOAD, which needs async wasm instantiation).
+//
+// Usage:
+//   node load_test.cjs --repo <repository-dir> --name <ext> --query <sql>
+//       [--expect <substr>] [--platform eh|mvp] [--engine <npm-pkg>]
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+const Worker = require("web-worker");
+
+function arg(name, def) { const i = process.argv.indexOf(`--${name}`); return i >= 0 ? process.argv[i + 1] : def; }
+
+const repoDir = arg("repo"), name = arg("name"), platform = arg("platform", "eh");
+const enginePkg = arg("engine", "@haybarn/haybarn-wasm"), query = arg("query"), expect = arg("expect");
+
+if (!repoDir || !name || !query) {
+  console.error("usage: node load_test.cjs --repo <dir> --name <ext> --query <sql> [--expect s] [--platform eh|mvp] [--engine pkg]");
+  process.exit(2);
+}
+
+const duckdb = require(`${enginePkg}/dist/duckdb-node`);
+const dist = path.dirname(require.resolve(`${enginePkg}/dist/duckdb-node.cjs`));
+const BUNDLES = {
+  mvp: { mainModule: path.join(dist, "duckdb-mvp.wasm"), mainWorker: path.join(dist, "duckdb-node-mvp.worker.cjs") },
+  eh: { mainModule: path.join(dist, "duckdb-eh.wasm"), mainWorker: path.join(dist, "duckdb-node-eh.worker.cjs") },
+};
+
+const server = http.createServer((req, res) => {
+  const fp = path.join(repoDir, decodeURIComponent(req.url.split("?")[0]));
+  if (!fp.startsWith(path.resolve(repoDir))) { res.writeHead(403); return res.end(); }
+  fs.readFile(fp, (err, buf) => {
+    if (err) { res.writeHead(404); return res.end(String(err)); }
+    res.writeHead(200, { "Content-Type": "application/wasm" }); res.end(buf);
+  });
+});
+
+(async () => {
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const repoUrl = `http://127.0.0.1:${server.address().port}`;
+  console.error(`[load_test] serving ${repoDir} at ${repoUrl}; engine=${enginePkg} platform=${platform}`);
+
+  const bundle = BUNDLES[platform];
+  const worker = new Worker(bundle.mainWorker);
+  const db = new duckdb.AsyncDuckDB(new duckdb.VoidLogger(), worker);
+  await db.instantiate(bundle.mainModule);
+  await db.open({ allowUnsignedExtensions: true });
+  const conn = await db.connect();
+
+  const ver = (await conn.query("SELECT version() AS v")).toArray()[0].v;
+  console.error(`[load_test] engine duckdb version: ${ver}`);
+  await conn.query(`SET custom_extension_repository='${repoUrl}'`);
+  console.error(`[load_test] INSTALL ${name}`); await conn.query(`INSTALL ${name}`);
+  console.error(`[load_test] LOAD ${name}`); await conn.query(`LOAD ${name}`);
+  console.error(`[load_test] query: ${query}`);
+  const rows = (await conn.query(query)).toArray();
+  const out = JSON.stringify(rows.map((r) => Object.fromEntries(Object.entries(r))));
+  console.error(`[load_test] result: ${out}`);
+
+  await conn.close(); await db.terminate(); await worker.terminate(); server.close();
+
+  if (expect !== undefined && !out.includes(expect)) {
+    console.error(`FAIL: expected substring '${expect}' not in result ${out}`); process.exit(1);
+  }
+  console.log(`PASS: ${name} loaded into duckdb-wasm ${ver} (${platform}) and query returned ${out}`);
+  process.exit(0);
+})().catch((e) => { console.error("FAIL:", e && e.message ? e.message : e); try { server.close(); } catch {} process.exit(1); });

--- a/test/wasm/package.json
+++ b/test/wasm/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "yaml-wasm-tests",
+  "private": true,
+  "description": "Dependencies for the duckdb-wasm live load test (load_test.cjs). The static check (check_wasm_imports.mjs / run_wasm_checks.sh) needs no dependencies.",
+  "dependencies": {
+    "@haybarn/haybarn-wasm": "1.5.3-rc15",
+    "web-worker": "1.2.0"
+  }
+}

--- a/test/wasm/run_wasm_checks.sh
+++ b/test/wasm/run_wasm_checks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run the WASM dependency-symbol check against built .wasm artifacts.
+#
+# This is the fast, deterministic gate for the LINKED_LIBS class of bug
+# (see check_wasm_imports.mjs for the full explanation). It does NOT need a
+# duckdb-wasm runtime or a matching duckdb version — it statically inspects
+# the side module's imports. Run it after `make wasm_mvp` / `wasm_eh`.
+#
+# Usage: test/wasm/run_wasm_checks.sh [build-dir ...]
+#   defaults to build/wasm_mvp build/wasm_eh build/wasm_threads if present.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+
+# Dependency symbols that MUST be resolved internally (not left as imports).
+# yaml-cpp is C++ (namespace YAML); its symbols mangle to contain "4YAML".
+FORBID=( --forbid '4YAML' --forbid 'yaml_cpp' )
+
+dirs=("$@")
+if [ ${#dirs[@]} -eq 0 ]; then
+  for d in build/wasm_mvp build/wasm_eh build/wasm_threads; do
+    [ -d "$repo_root/$d" ] && dirs+=("$repo_root/$d")
+  done
+fi
+
+if [ ${#dirs[@]} -eq 0 ]; then
+  echo "no wasm build dirs found; build first (e.g. make wasm_mvp)" >&2
+  exit 2
+fi
+
+found_any=0
+rc=0
+for d in "${dirs[@]}"; do
+  while IFS= read -r -d '' wasm; do
+    found_any=1
+    echo "==> checking $wasm"
+    node "$here/check_wasm_imports.mjs" "$wasm" "${FORBID[@]}" || rc=1
+  done < <(find "$d" -name '*.duckdb_extension.wasm' -print0 2>/dev/null)
+done
+
+if [ "$found_any" -eq 0 ]; then
+  echo "no *.duckdb_extension.wasm found under: ${dirs[*]}" >&2
+  exit 2
+fi
+exit $rc


### PR DESCRIPTION
Fixes #40.

## Root cause
The loadable `*.duckdb_extension.wasm` is produced by a separate
`emcc -sSIDE_MODULE=2 ... ${LINKED_LIBS}` post-build step in duckdb's
`extension/extension_build_tools.cmake`. That link pulls in **only** the
libraries named in `LINKED_LIBS` in `extension_config.cmake`; the
`target_link_libraries(... yaml-cpp::yaml-cpp)` in `CMakeLists.txt` is honored
for native builds but **ignored** for the wasm side-module link. So yaml-cpp's
symbols (functions, vtables, typeinfo) were left as unresolved imports and the
module failed to load in duckdb-wasm. (Same class of bug @rustyconover reported
across several extensions.)

## Fix
Name yaml-cpp in `LINKED_LIBS`:
```cmake
duckdb_extension_load(yaml
    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
    LOAD_TESTS
    LINKED_LIBS "$<TARGET_FILE:yaml-cpp::yaml-cpp>"
)
```

## Test harness (`test/wasm/`)
The reusable distribution workflow **builds and uploads** the `.wasm` but never
inspects or loads it — which is why this shipped green. Added:

- `check_wasm_imports.mjs` — a static, runtime-free check (node only, no
  duckdb-wasm engine, no duckdb-version match needed) that fails when a
  dependency symbol is **imported but not defined/exported** by the side module.
  Resolution is bucket-aware: `env`/`GOT.func` → exported functions,
  `GOT.mem` → exported data globals, so unresolved **vtables**/**typeinfo** are
  caught too, not just functions. Being runtime-free, a failure is
  unambiguously this LINKED_LIBS bug and not an ABI/version mismatch.
- `run_wasm_checks.sh` — wrapper that scans build/artifact dirs.
- `wasm-symbol-check` job in `MainDistributionPipeline.yml` — downloads the
  v1.5.3 wasm artifacts and runs the check.

## Verification
Built with emsdk 3.1.71 (`wasm_mvp`, matching CI), broken vs fixed:

| build | unresolved yaml-cpp symbols |
|---|---|
| before (no LINKED_LIBS) | **38** — `YAML::Load`, `YAML::Emitter::*`, `YAML::detail::node_data::*`, `_ZTVN4YAML9ExceptionE`, … |
| after | **0** across all symbol kinds |

## What is and isn't verified
- ✅ Symbol resolution: 0 unresolved yaml-cpp symbols, clean red→green on `wasm_mvp`.
- ⚠️ Not yet exercised: actual end-to-end **load + query** in duckdb-wasm
  (@rustyconover's `haybarn-extension-wasm-tester` is the natural layer for that;
  documented in `test/wasm/README.md`). The static check proves the necessary
  condition (no unresolved deps), not instantiation.
- ⚠️ `wasm_eh`/`wasm_threads` and the native build use the identical
  `LINKED_LIBS` link path but were not separately built here.
