### PR TITLE
fix: widen cross-row numeric types in read_yaml (#42)

### DIFF
--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -317,6 +317,16 @@ public:
 	static LogicalType MergeStructTypes(const LogicalType &type1, const LogicalType &type2);
 
 	/**
+	 * @brief Widen two differing scalar field types to a common type (issue #42).
+	 *
+	 * Numeric types promote along DOUBLE > HUGEINT > BIGINT > INTEGER > SMALLINT so that e.g.
+	 * TINYINT + SMALLINT -> SMALLINT and INT + DOUBLE -> DOUBLE, matching the within-node
+	 * sequence widening. Genuinely incompatible pairs (number vs string) return the YAML type.
+	 * Callers that want a VARCHAR fallback instead should guard on IsNumeric() before calling.
+	 */
+	static LogicalType WidenConflictingScalarTypes(const LogicalType &type1, const LogicalType &type2);
+
+	/**
 	 * @brief Bind the columns parameter for explicit type specification
 	 *
 	 * @param context Client context

--- a/src/yaml_frontmatter.cpp
+++ b/src/yaml_frontmatter.cpp
@@ -200,7 +200,12 @@ static unique_ptr<FunctionData> YAMLFrontmatterBind(ClientContext &context, Tabl
 					           value_type.id() == LogicalTypeId::STRUCT) {
 						merged_types[key] = YAMLReader::MergeStructTypes(existing->second, value_type);
 					} else if (existing->second.id() != value_type.id()) {
-						merged_types[key] = LogicalType::VARCHAR;
+						// Widen compatible numerics across frontmatter docs; VARCHAR otherwise (issue #42).
+						if (existing->second.IsNumeric() && value_type.IsNumeric()) {
+							merged_types[key] = YAMLReader::WidenConflictingScalarTypes(existing->second, value_type);
+						} else {
+							merged_types[key] = LogicalType::VARCHAR;
+						}
 					}
 				}
 			} catch (...) {

--- a/src/yaml_reader_functions.cpp
+++ b/src/yaml_reader_functions.cpp
@@ -47,7 +47,7 @@ static MultiDocumentMode ParseMultiDocumentMode(const Value &value) {
 // widening in yaml_reader_types.cpp so the multi-row read_yaml case is consistent with it.
 // Genuinely incompatible types (e.g. number vs string) still fall back to YAML to preserve data.
 // (issue #42: cross-row numeric type degradation)
-static LogicalType WidenConflictingScalarTypes(const LogicalType &a, const LogicalType &b) {
+LogicalType YAMLReader::WidenConflictingScalarTypes(const LogicalType &a, const LogicalType &b) {
 	if (a.IsNumeric() && b.IsNumeric()) {
 		if (a.id() == LogicalTypeId::DOUBLE || b.id() == LogicalTypeId::DOUBLE || a.id() == LogicalTypeId::FLOAT ||
 		    b.id() == LogicalTypeId::FLOAT) {

--- a/src/yaml_reader_functions.cpp
+++ b/src/yaml_reader_functions.cpp
@@ -41,6 +41,33 @@ static MultiDocumentMode ParseMultiDocumentMode(const Value &value) {
 // For example, if document1 has {user: {profile: {name: "John"}}} and
 // document2 has {user: {profile: {name: "Jane", age: 42}}},
 // we need to make sure the final schema includes both name and age in the profile struct
+// When two records give a field different scalar types, widen to a common type instead of
+// dropping to the YAML/VARCHAR fallback. Numeric types promote along the ladder
+// (DOUBLE > HUGEINT > BIGINT > INTEGER > SMALLINT > TINYINT), matching the within-node sequence
+// widening in yaml_reader_types.cpp so the multi-row read_yaml case is consistent with it.
+// Genuinely incompatible types (e.g. number vs string) still fall back to YAML to preserve data.
+// (issue #42: cross-row numeric type degradation)
+static LogicalType WidenConflictingScalarTypes(const LogicalType &a, const LogicalType &b) {
+	if (a.IsNumeric() && b.IsNumeric()) {
+		if (a.id() == LogicalTypeId::DOUBLE || b.id() == LogicalTypeId::DOUBLE || a.id() == LogicalTypeId::FLOAT ||
+		    b.id() == LogicalTypeId::FLOAT) {
+			return LogicalType::DOUBLE;
+		}
+		if (a.id() == LogicalTypeId::HUGEINT || b.id() == LogicalTypeId::HUGEINT) {
+			return LogicalType::HUGEINT;
+		}
+		if (a.id() == LogicalTypeId::BIGINT || b.id() == LogicalTypeId::BIGINT) {
+			return LogicalType::BIGINT;
+		}
+		if (a.id() == LogicalTypeId::INTEGER || b.id() == LogicalTypeId::INTEGER) {
+			return LogicalType::INTEGER;
+		}
+		// Any remaining pair of differing small integer types (incl. mixed signedness) fits in SMALLINT.
+		return LogicalType::SMALLINT;
+	}
+	return YAMLTypes::YAMLType();
+}
+
 LogicalType YAMLReader::MergeStructTypes(const LogicalType &type1, const LogicalType &type2) {
 	if (type1.id() != LogicalTypeId::STRUCT || type2.id() != LogicalTypeId::STRUCT) {
 		// Type conflict (e.g., STRUCT vs scalar) - fall back to YAML to preserve data
@@ -82,12 +109,15 @@ LogicalType YAMLReader::MergeStructTypes(const LogicalType &type1, const Logical
 					if (merged_child.id() == LogicalTypeId::STRUCT && child2_child.id() == LogicalTypeId::STRUCT) {
 						merged_children[i].second = LogicalType::LIST(MergeStructTypes(merged_child, child2_child));
 					} else if (merged_child.id() != child2_child.id()) {
-						// Different child types - fall back to YAML list
-						merged_children[i].second = LogicalType::LIST(YAMLTypes::YAMLType());
+						// Different list child scalar types - widen instead of collapsing to YAML (issue #42).
+						merged_children[i].second =
+						    LogicalType::LIST(WidenConflictingScalarTypes(merged_child, child2_child));
 					}
 				} else if (merged_children[i].second.id() != child2.second.id()) {
-					// Different types within struct fields - fall back to YAML to preserve data
-					merged_children[i].second = YAMLTypes::YAMLType();
+					// Different scalar types for a field across records - widen (e.g. TINYINT +
+					// SMALLINT -> SMALLINT) instead of collapsing to YAML (issue #42).
+					merged_children[i].second =
+					    WidenConflictingScalarTypes(merged_children[i].second, child2.second);
 				}
 				found = true;
 				break;
@@ -541,8 +571,10 @@ unique_ptr<FunctionData> YAMLReader::YAMLReadRowsBind(ClientContext &context, Ta
 					// Merge the two struct definitions recursively to preserve all fields
 					detected_types[key] = MergeStructTypes(detected_types[key], value_type);
 				} else if (detected_types[key].id() != value_type.id()) {
-					// Type conflict - fall back to YAML type to preserve data
-					detected_types[key] = YAMLTypes::YAMLType();
+					// Different scalar types for a column across records - widen compatible numerics
+					// (e.g. TINYINT + SMALLINT -> SMALLINT, INT + DOUBLE -> DOUBLE) instead of
+					// collapsing to YAML, matching within-node sequence widening (issue #42).
+					detected_types[key] = WidenConflictingScalarTypes(detected_types[key], value_type);
 				}
 			}
 		}

--- a/src/yaml_reader_types.cpp
+++ b/src/yaml_reader_types.cpp
@@ -250,8 +250,14 @@ LogicalType YAMLReader::DetectJaggedYAMLType(const vector<YAML::Node> &nodes) {
 				merged_type = node_type;
 			}
 		} else if (merged_type.id() != node_type.id()) {
-			// Different types, fall back to VARCHAR
-			merged_type = LogicalType::VARCHAR;
+			// Different scalar types across nodes - widen compatible numerics (TINYINT + SMALLINT
+			// -> SMALLINT, INT + DOUBLE -> DOUBLE); keep the VARCHAR fallback for genuinely
+			// incompatible pairs (issue #42).
+			if (merged_type.IsNumeric() && node_type.IsNumeric()) {
+				merged_type = YAMLReader::WidenConflictingScalarTypes(merged_type, node_type);
+			} else {
+				merged_type = LogicalType::VARCHAR;
+			}
 		}
 	}
 

--- a/test/sql/yaml_cross_row_widening.test
+++ b/test/sql/yaml_cross_row_widening.test
@@ -1,0 +1,31 @@
+# name: test/sql/yaml_cross_row_widening.test
+# description: Cross-row numeric type widening in read_yaml (#42)
+# group: [sql]
+
+require yaml
+
+# A field whose integer width differs across records widens to a common numeric type
+# (TINYINT 5 + SMALLINT 5000 -> SMALLINT) instead of collapsing to the YAML type. This matches
+# the within-node sequence widening; previously the multi-row case fell back to yaml.
+query I
+SELECT typeof(count) FROM read_yaml('test/yaml/cross_row_widening.yaml') LIMIT 1;
+----
+SMALLINT
+
+# integer + double across records -> DOUBLE.
+query I
+SELECT typeof(ratio) FROM read_yaml('test/yaml/cross_row_widening.yaml') LIMIT 1;
+----
+DOUBLE
+
+# The widened column is a real number, usable in numeric ops (not a string).
+query I
+SELECT sum(count) FROM read_yaml('test/yaml/cross_row_widening.yaml');
+----
+5005
+
+# Genuinely incompatible types (number + string) still fall back to yaml to preserve data.
+query I
+SELECT typeof(mixed) FROM read_yaml('test/yaml/cross_row_widening.yaml') LIMIT 1;
+----
+yaml

--- a/test/yaml/cross_row_widening.yaml
+++ b/test/yaml/cross_row_widening.yaml
@@ -1,0 +1,6 @@
+- count: 5
+  ratio: 1
+  mixed: 1
+- count: 5000
+  ratio: 2.5
+  mixed: hello


### PR DESCRIPTION
Addresses the cross-row numeric type-degradation item in #42.

read_yaml merged each field's type across records but collapsed to the YAML type on any type-id difference — so `count: 5` (TINYINT) + `count: 5000` (SMALLINT) became a `yaml`/VARCHAR column instead of `SMALLINT`, breaking numeric ops. The within-node sequence path already widened, so the common multi-row case was the inconsistent/broken one.

- Added `WidenConflictingScalarTypes` (DOUBLE > HUGEINT > BIGINT > INTEGER > SMALLINT), used at the cross-record reconcile site and both `MergeStructTypes` fallbacks.
- Numeric conflicts widen; genuinely incompatible types (number vs string) still fall back to `yaml`.

**Validated on a local v1.5-variegata build** (the vcpkg/`mnt/fast` build issue is now sorted): the new `yaml_cross_row_widening.test` passes (SMALLINT, DOUBLE, `sum()` usable, mixed number/string still `yaml`), and all 31 type/column/reader tests pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)