### PR TITLE
compat: build against DuckDB v2.0 (main) as well as the pinned v1.5.4

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -15,7 +15,16 @@ jobs:
   # Forward-compat canary: intentionally tracks duckdb `main`; expected to go
   # red on upstream API drift and is NOT a merge blocker.
   duckdb-next-build:
-    name: Build extension binaries
+    name: DuckDB main canary
+    # Gated so it does not show red on every PR. `push` and `pull_request` both
+    # fire on the same commit and a PR's check rollup includes both, so an
+    # ungated canary that tracks upstream API drift makes every PR look broken.
+    # This must be `if:` and NOT `continue-on-error:` — a job that calls a
+    # REUSABLE workflow accepts only a fixed key set, and adding
+    # continue-on-error makes the whole workflow fail to parse (scheduling zero
+    # jobs, including the shippable build). Run it on demand with:
+    #   gh workflow run MainDistributionPipeline.yml --ref <branch>
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       duckdb_version: main

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -288,3 +288,189 @@ inline const unique_ptr<FunctionData> &CompatBoundBindInfo(const BoundFunctionEx
 }
 #endif
 } // namespace duckdb
+
+// === DuckDB v2.0 (duckdb `main`) shims (appended) ===
+//
+// These cover the change classes documented in duckdb_markdown's
+// docs/duckdb_v2_migration.md that the sections above do not already handle.
+//
+// FEATURE DETECTION, NOT VERSION NUMBERS, and each change is probed
+// SEPARATELY. A version macro says *when* a thing changed; a probe says whether
+// it changed *here*, which keeps working when a change is backported, reverted,
+// or lands on a branch nobody expected. Tying several changes to one macro
+// silently picks the wrong branch the moment they land in different releases --
+// so these deliberately do NOT reuse DUCKDB_HAS_NEW_VECTOR_HEADERS.
+//
+// <type_traits> is C++11, so it is safe to include unconditionally: this header
+// is compiled at -std=c++11 against the pinned v1.5.x DuckDB (see the note at
+// the top of the file about why the extension must not be forced to C++17).
+
+#include <type_traits>
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// CompatName / CompatNameStr / CompatMakeName -- bind-signature name type
+//===--------------------------------------------------------------------===//
+//
+// v2.0 changed `table_function_bind_t` and `copy_to_bind_t` to take
+// `vector<Identifier> &names` where v1.5 took `vector<string> &names`.
+//
+// This is a DIFFERENT boundary from CompatIdentifierName / CompatMakeIdentifier
+// above, which exist for the child_list_t (STRUCT field name) key and for
+// expression/function name fields. Both boundaries happen to be driven by the
+// same upstream Identifier type, but they are distinct call sites with distinct
+// lifetimes -- keep them separate rather than merging them.
+//
+// Note the conversion asymmetry that makes this cheap:
+//     Identifier(const char *)        is IMPLICIT  -- literals are identifiers by intent
+//     explicit Identifier(const string &)          -- promoting a runtime string is deliberate
+// so `names.emplace_back("frontmatter")` needs no change on either version; only
+// the signatures move, plus the handful of places a *runtime* string crosses.
+#ifdef DUCKDB_HAS_IDENTIFIER
+using CompatName = Identifier;
+inline string CompatNameStr(const Identifier &name) {
+	return name.GetIdentifierName();
+}
+inline Identifier CompatMakeName(string name) {
+	return Identifier(std::move(name));
+}
+#else
+using CompatName = string;
+inline string CompatNameStr(const string &name) {
+	return name;
+}
+inline string CompatMakeName(string name) {
+	return name;
+}
+#endif
+
+//! Whole-vector conversions for the same boundary. A bind function fills a
+//! `vector<CompatName>` but the bind DATA keeps plain `vector<string>` (it is
+//! compared and sliced with string operations downstream), so the two vectors
+//! have to be converted rather than assigned. No-ops on v1.5.x.
+inline vector<string> CompatNameStrings(const vector<CompatName> &names) {
+	vector<string> result;
+	result.reserve(names.size());
+	for (const auto &name : names) {
+		result.push_back(CompatNameStr(name));
+	}
+	return result;
+}
+inline vector<CompatName> CompatMakeNames(const vector<string> &names) {
+	vector<CompatName> result;
+	result.reserve(names.size());
+	for (const auto &name : names) {
+		result.push_back(CompatMakeName(name));
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
+// CompatWithAlias -- LogicalType alias
+//===--------------------------------------------------------------------===//
+//
+// v1.5: void SetAlias(string)               -- mutates in place
+// v2.0: LogicalType WithAlias(string) const -- returns a copy, so it never
+//       mutates a type whose type-info is shared with other types.
+//
+// SetAlias is REMOVED on v2.0, not deprecated.
+//
+// Dispatched on a tag rather than with `if constexpr`, so this compiles at
+// C++11 (which is what this extension builds at -- see the header preamble).
+// Tag dispatch has the property that matters here: only the selected overload
+// is instantiated, so the branch naming the absent member is never compiled.
+template <class T, class = void>
+struct CompatHasWithAlias : std::false_type {};
+template <class T>
+struct CompatHasWithAlias<T, decltype(void(std::declval<const T &>().WithAlias(string())))> : std::true_type {};
+
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::true_type) {
+	return type.WithAlias(std::move(alias));
+}
+template <class TYPE>
+inline LogicalType CompatWithAliasImpl(TYPE type, string alias, std::false_type) {
+	type.SetAlias(std::move(alias));
+	return type;
+}
+// The entry point is deliberately NOT a template: `LogicalType::VARCHAR` and
+// friends are `LogicalTypeId` constants, so a deduced parameter binds TYPE to
+// LogicalTypeId and then fails inside the shim ("request for member 'SetAlias'
+// in 'type', which is of non-class type 'duckdb::LogicalTypeId'"). A concrete
+// LogicalType parameter makes the usual implicit conversion happen at the call
+// site instead. The dispatch below is still a template, so only the selected
+// overload is instantiated and the branch naming the absent member is never
+// compiled.
+inline LogicalType CompatWithAlias(LogicalType type, string alias) {
+	return CompatWithAliasImpl(std::move(type), std::move(alias), CompatHasWithAlias<LogicalType>());
+}
+
+//===--------------------------------------------------------------------===//
+// CompatSetCaptureArgumentAliases -- named arguments derived from aliases
+//===--------------------------------------------------------------------===//
+//
+// A SILENT RUNTIME BREAK, not a compile error: v2.0 added
+// FunctionProperties::capture_argument_aliases, DEFAULTING TO FALSE. On v1.5 the
+// binder always recorded a named argument's alias on the bound child expression,
+// so a bind callback could recover `style := 'block'` with child->GetAlias(). On
+// v2.0 that alias comes back EMPTY unless the function opts in, so a function
+// that derives named parameters from argument aliases binds every argument as
+// unnamed and fails at RUNTIME -- with a completely green build and nothing to
+// grep for. (duckdb's own struct_pack/row call SetCaptureArgumentAliases(true)
+// for exactly this reason.)
+//
+// No-op on v1.5.x, where the capture was unconditional.
+template <class T, class = void>
+struct CompatHasSetCaptureArgumentAliases : std::false_type {};
+template <class T>
+struct CompatHasSetCaptureArgumentAliases<T, decltype(void(std::declval<T &>().SetCaptureArgumentAliases(true)))>
+    : std::true_type {};
+
+template <class FUNC>
+inline void CompatSetCaptureArgumentAliasesImpl(FUNC &fun, std::true_type) {
+	fun.SetCaptureArgumentAliases(true);
+}
+template <class FUNC>
+inline void CompatSetCaptureArgumentAliasesImpl(FUNC &, std::false_type) {
+}
+template <class FUNC>
+inline void CompatSetCaptureArgumentAliases(FUNC &fun) {
+	CompatSetCaptureArgumentAliasesImpl(fun, CompatHasSetCaptureArgumentAliases<FUNC>());
+}
+
+//===--------------------------------------------------------------------===//
+// CompatFlatDataMutable -- FlatVector write access
+//===--------------------------------------------------------------------===//
+//
+// v1.5: FlatVector::GetData<T>(vec)        returns T*
+// v2.0: FlatVector::GetData<T>(vec)        returns const T*
+//       FlatVector::GetDataMutable<T>(vec) returns T*
+//
+// Writing through the v2.0 read accessor is a compile error, which is the whole
+// point of the split, so the WRITE path has to ask for mutability explicitly.
+// Probing for GetDataMutable (the member that exists only on v2.0) rather than
+// for GetData (which exists on both) is what makes the probe discriminate.
+//
+// ConstantVector::GetData<T> kept its non-const overload, so writes through
+// *it* need no shim.
+template <class T, class = void>
+struct CompatHasFlatGetDataMutable : std::false_type {};
+template <class T>
+struct CompatHasFlatGetDataMutable<T, decltype(void(T::template GetDataMutable<bool>(std::declval<Vector &>())))>
+    : std::true_type {};
+
+template <class VALUE, class FV>
+inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::true_type) {
+	return FV::template GetDataMutable<VALUE>(vec);
+}
+template <class VALUE, class FV>
+inline VALUE *CompatFlatDataMutableImpl(Vector &vec, std::false_type) {
+	return FV::template GetData<VALUE>(vec);
+}
+template <class VALUE, class FV = FlatVector>
+inline VALUE *CompatFlatDataMutable(Vector &vec) {
+	return CompatFlatDataMutableImpl<VALUE, FV>(vec, CompatHasFlatGetDataMutable<FV>());
+}
+
+} // namespace duckdb

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -382,6 +382,18 @@ inline CompatName CompatMakeName(string name) {
 	return CompatMakeNameImpl(std::move(name), static_cast<const CompatName *>(nullptr));
 }
 
+//! Cross-check the derivation against a SECOND, independent entity. CompatName
+//! comes from TableFunctionBindInput::input_table_names; this asserts that a
+//! bind function written with it is actually assignable to table_function_bind_t.
+//! DuckDB could in principle change those two independently, which is what makes
+//! this load-bearing rather than tautological -- and it turns the next submodule
+//! bump from a cascade of confusing signature errors into one clear message.
+typedef unique_ptr<FunctionData> (*CompatBindSignatureCheck)(ClientContext &, TableFunctionBindInput &,
+                                                             vector<LogicalType> &, vector<CompatName> &);
+static_assert(std::is_convertible<CompatBindSignatureCheck, table_function_bind_t>::value,
+              "CompatName does not match table_function_bind_t's name parameter. The DuckDB submodule has "
+              "moved this boundary: re-derive CompatName from the bind signature rather than patching call sites.");
+
 //! Whole-vector conversions for the same boundary. A bind function fills a
 //! `vector<CompatName>` but the bind DATA keeps plain `vector<string>` (it is
 //! compared and sliced with string operations downstream), so the two vectors

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -149,24 +149,42 @@ inline void CompatBinaryExecuteWithNulls(Vector &left, Vector &right, Vector &re
 
 namespace duckdb {
 
+// Reading is safe to overload unconditionally -- whichever type shows up at the
+// call site picks its overload, and the Identifier one only has to EXIST when
+// the type does.
+inline const string &CompatIdentifierName(const string &name) {
+	return name;
+}
 #ifdef DUCKDB_HAS_IDENTIFIER
 inline const string &CompatIdentifierName(const Identifier &id) {
 	return id.GetIdentifierName();
 }
-inline const string &CompatIdentifierName(const string &name) {
+#endif
+
+// Constructing is where the choice has to be right, and `__has_include` is the
+// WRONG basis for it -- see the long note on CompatName below. identifier.hpp
+// has been backported to the stable v1.5-variegata branch without child_list_t
+// changing its key type, so the header probe would flip this to Identifier on a
+// DuckDB that still wants string. Derive it from the boundary instead: this
+// helper's job is to produce a child_list_t key (STRUCT field names), and
+// TableFunctionRef::alias and FunctionSet::name move with it.
+//
+// No `typename`: child_list_t<LogicalType> is a concrete type here, and
+// `typename` outside a template is only valid from C++20 (this header compiles
+// at C++11).
+using CompatIdentifierKey = child_list_t<LogicalType>::value_type::first_type;
+
+inline string CompatMakeIdentifierImpl(string name, const string *) {
 	return name;
 }
-inline Identifier CompatMakeIdentifier(string name) {
+#ifdef DUCKDB_HAS_IDENTIFIER
+inline Identifier CompatMakeIdentifierImpl(string name, const Identifier *) {
 	return Identifier(std::move(name));
 }
-#else
-inline const string &CompatIdentifierName(const string &name) {
-	return name;
-}
-inline string CompatMakeIdentifier(string name) {
-	return name;
-}
 #endif
+inline CompatIdentifierKey CompatMakeIdentifier(string name) {
+	return CompatMakeIdentifierImpl(std::move(name), static_cast<const CompatIdentifierKey *>(nullptr));
+}
 
 } // namespace duckdb
 
@@ -306,6 +324,8 @@ inline const unique_ptr<FunctionData> &CompatBoundBindInfo(const BoundFunctionEx
 // the top of the file about why the extension must not be forced to C++17).
 
 #include <type_traits>
+#include <utility>
+#include "duckdb/function/table_function.hpp"
 
 namespace duckdb {
 
@@ -316,34 +336,50 @@ namespace duckdb {
 // v2.0 changed `table_function_bind_t` and `copy_to_bind_t` to take
 // `vector<Identifier> &names` where v1.5 took `vector<string> &names`.
 //
-// This is a DIFFERENT boundary from CompatIdentifierName / CompatMakeIdentifier
-// above, which exist for the child_list_t (STRUCT field name) key and for
-// expression/function name fields. Both boundaries happen to be driven by the
-// same upstream Identifier type, but they are distinct call sites with distinct
-// lifetimes -- keep them separate rather than merging them.
+// DO NOT SELECT THIS TYPE WITH `__has_include("duckdb/common/identifier.hpp")`.
+// That is the obvious probe and it is a TIME BOMB. identifier.hpp has already
+// been BACKPORTED to the stable v1.5-variegata branch WITHOUT changing the bind
+// signature, so on three real heads:
 //
-// Note the conversion asymmetry that makes this cheap:
-//     Identifier(const char *)        is IMPLICIT  -- literals are identifiers by intent
-//     explicit Identifier(const string &)          -- promoting a runtime string is deliberate
-// so `names.emplace_back("frontmatter")` needs no change on either version; only
-// the signatures move, plus the handful of places a *runtime* string crosses.
-#ifdef DUCKDB_HAS_IDENTIFIER
-using CompatName = Identifier;
-inline string CompatNameStr(const Identifier &name) {
-	return name.GetIdentifierName();
-}
-inline Identifier CompatMakeName(string name) {
-	return Identifier(std::move(name));
-}
-#else
-using CompatName = string;
+//   v1.5-variegata @ b155d6f63c (our pin)   no identifier.hpp   bind: vector<string>
+//   v1.5-variegata @ branch tip             HAS identifier.hpp  bind: vector<string>
+//   main (v2.0)                             HAS identifier.hpp  bind: vector<Identifier>
+//
+// the header probe agrees with reality only because our pin predates the
+// backport. The next submodule bump would flip CompatName to Identifier on a
+// DuckDB that still wants strings, and every bind signature in the extension
+// would stop compiling at once.
+//
+// So derive the type from the boundary itself. TableFunctionBindInput's
+// `input_table_names` has the same element type as the bind out-parameter on
+// both lines (table_function.hpp:110 / :289 on the pin; :123 / :319 on main),
+// which makes this exact by construction rather than by correlation.
+using CompatName =
+    std::remove_reference<decltype(std::declval<TableFunctionBindInput &>().input_table_names)>::type::value_type;
+
+// The Identifier overloads below are still gated on the header, because the
+// TYPE has to exist before it can be named. That gate decides only whether an
+// overload can be declared -- never which type CompatName is.
 inline string CompatNameStr(const string &name) {
 	return name;
 }
-inline string CompatMakeName(string name) {
+inline string CompatMakeNameImpl(string name, const string *) {
 	return name;
 }
+#ifdef DUCKDB_HAS_IDENTIFIER
+inline string CompatNameStr(const Identifier &name) {
+	return name.GetIdentifierName();
+}
+inline Identifier CompatMakeNameImpl(string name, const Identifier *) {
+	return Identifier(std::move(name));
+}
 #endif
+//! Promote a RUNTIME string to whatever the bind signature wants. Literals need
+//! no helper: Identifier(const char *) is implicit by design, precisely so that
+//! only deliberate runtime promotions have to be spelled out.
+inline CompatName CompatMakeName(string name) {
+	return CompatMakeNameImpl(std::move(name), static_cast<const CompatName *>(nullptr));
+}
 
 //! Whole-vector conversions for the same boundary. A bind function fills a
 //! `vector<CompatName>` but the bind DATA keeps plain `vector<string>` (it is
@@ -437,6 +473,94 @@ inline void CompatSetCaptureArgumentAliasesImpl(FUNC &, std::false_type) {
 template <class FUNC>
 inline void CompatSetCaptureArgumentAliases(FUNC &fun) {
 	CompatSetCaptureArgumentAliasesImpl(fun, CompatHasSetCaptureArgumentAliases<FUNC>());
+}
+
+//===--------------------------------------------------------------------===//
+// CompatSetFallible -- functions that can throw at execution time
+//===--------------------------------------------------------------------===//
+//
+// A SILENT RUNTIME BREAK. v2.0 requires a scalar function that can throw during
+// execution to say so; throwing from one that has not becomes
+//
+//   INTERNAL Error: Scalar function "f" threw an execution error, but the
+//   function is not marked as fallible - the function must call SetFallible().
+//
+// There is no compile error and nothing in the DuckDB API to grep for -- the
+// thing to grep is your own `throw` statements inside execution bodies, plus
+// the transitive callers of throwing helpers. Enforcement is an assertion, so
+// a canary leg built without assertions can be green while the contract is
+// violated; do not read a green arch as proof.
+//
+// IMPORTANT: this is NOT a v2.0-only concept and the shim is NOT a no-op on
+// v1.5.x. BaseScalarFunction::SetFallible() exists on the pinned v1.5.4 too
+// (function.hpp), and `errors` feeds Expression::CanThrow(), which gates
+// conjunct reordering, filter pushdown and dictionary caching. v2.0 only added
+// ENFORCEMENT of a contract that already existed. So mark PRECISELY: declaring
+// a function fallible when it cannot throw is itself an optimizer-visible
+// change on the version this extension ships.
+//
+// The shim exists only for the FunctionSet case. A plain ScalarFunction (or
+// AggregateFunction) has SetFallible() on both lines and could call it
+// directly; a FunctionSet gained a set-level SetFallible() only on v2.0, where
+// its members became immutable shared_ptr<const T> and can no longer be
+// iterated and mutated the way v1.5's vector<T> can.
+template <class T, class = void>
+struct CompatHasSetFallible : std::false_type {};
+template <class T>
+struct CompatHasSetFallible<T, decltype(void(std::declval<T &>().SetFallible()))> : std::true_type {};
+
+//! Direct: a function on either line, or a v2.0 set (which applies it to every overload).
+template <class FUNC>
+inline void CompatSetFallibleImpl(FUNC &fun, std::true_type) {
+	fun.SetFallible();
+}
+//! v1.5 FunctionSet: no set-level setter, but the overloads are still mutable.
+template <class SET>
+inline void CompatSetFallibleImpl(SET &set, std::false_type) {
+	for (auto &fun : set.functions) {
+		fun.SetFallible();
+	}
+}
+template <class FUNC>
+inline void CompatSetFallible(FUNC &fun) {
+	CompatSetFallibleImpl(fun, CompatHasSetFallible<FUNC>());
+}
+
+//===--------------------------------------------------------------------===//
+// CompatFlatValidityMutable -- FlatVector validity write access
+//===--------------------------------------------------------------------===//
+//
+// The same const split as CompatFlatDataMutable, applied to the validity mask:
+//   v2.0: FlatVector::Validity(const Vector &)  -> const ValidityMask &  (Buffer())
+//         FlatVector::ValidityMutable(Vector &) ->       ValidityMask &  (BufferMutable())
+// BufferMutable() un-shares a copy-on-write buffer first; Buffer() does not.
+//
+// This one hides better than the data split: the accessor call still COMPILES,
+// silently deducing a const reference, and the diagnostic only appears at the
+// mutation as "passing 'const duckdb::ValidityMask' as 'this' argument discards
+// qualifiers". So grep the MUTATION, not the accessor:
+//   grep -rn 'SetInvalid\|SetValid(\|SetAllInvalid\|SetAllValid' src/
+//
+// (This extension has no direct FlatVector::Validity call site today -- every
+// SetInvalid here is on the ValidityMask the executor hands to a lambda -- but
+// the shim lives here because this header is the shared reference for the
+// duck_block extension family.)
+template <class T, class = void>
+struct CompatHasValidityMutable : std::false_type {};
+template <class T>
+struct CompatHasValidityMutable<T, decltype(void(T::ValidityMutable(std::declval<Vector &>())))> : std::true_type {};
+
+template <class FV>
+inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::true_type) {
+	return FV::ValidityMutable(vec);
+}
+template <class FV>
+inline ValidityMask &CompatFlatValidityMutableImpl(Vector &vec, std::false_type) {
+	return FV::Validity(vec);
+}
+template <class FV = FlatVector>
+inline ValidityMask &CompatFlatValidityMutable(Vector &vec) {
+	return CompatFlatValidityMutableImpl<FV>(vec, CompatHasValidityMutable<FV>());
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/include/duckdb_compat.hpp
+++ b/src/include/duckdb_compat.hpp
@@ -98,14 +98,15 @@ inline void SetValueCasted(ClientContext &context, Vector &vec, idx_t idx, const
 
 template <class INPUT_TYPE, class RESULT_TYPE, class FUNC>
 inline void CompatUnaryExecuteWithNulls(Vector &input, Vector &result, idx_t count, FUNC fun) {
-	UnaryExecutor::Execute<INPUT_TYPE, RESULT_TYPE>(input, result, count, [fun](INPUT_TYPE in) -> std::optional<RESULT_TYPE> {
-		ValidityMask scratch; // default-constructed → all rows valid
-		RESULT_TYPE val = fun(in, scratch, idx_t(0));
-		if (!scratch.RowIsValid(0)) {
-			return std::nullopt;
-		}
-		return val;
-	});
+	UnaryExecutor::Execute<INPUT_TYPE, RESULT_TYPE>(input, result, count,
+	                                                [fun](INPUT_TYPE in) -> std::optional<RESULT_TYPE> {
+		                                                ValidityMask scratch; // default-constructed → all rows valid
+		                                                RESULT_TYPE val = fun(in, scratch, idx_t(0));
+		                                                if (!scratch.RowIsValid(0)) {
+			                                                return std::nullopt;
+		                                                }
+		                                                return val;
+	                                                });
 }
 
 template <class LEFT_TYPE, class RIGHT_TYPE, class RESULT_TYPE, class FUNC>
@@ -206,8 +207,8 @@ inline CompatIdentifierKey CompatMakeIdentifier(string name) {
 #define DUCKDB_SCALAR_BIND_CONTEXT bind_input.GetClientContext()
 #define DUCKDB_SCALAR_BIND_ARGS    bind_input.GetArguments()
 #else
-#define DUCKDB_SCALAR_BIND_PARAMS                                                                                       \
-	duckdb::ClientContext &context, duckdb::ScalarFunction &bound_function,                                             \
+#define DUCKDB_SCALAR_BIND_PARAMS                                                                                      \
+	duckdb::ClientContext &context, duckdb::ScalarFunction &bound_function,                                            \
 	    duckdb::vector<duckdb::unique_ptr<duckdb::Expression>> &arguments
 #define DUCKDB_SCALAR_BIND_CONTEXT context
 #define DUCKDB_SCALAR_BIND_ARGS    arguments

--- a/src/include/yaml_reader.hpp
+++ b/src/include/yaml_reader.hpp
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <vector>
 #include "duckdb.hpp"
+#include "duckdb_compat.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -124,7 +125,7 @@ private:
 	 * @return Function data for execution
 	 */
 	static unique_ptr<FunctionData> YAMLReadRowsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                 vector<LogicalType> &return_types, vector<string> &names);
+	                                                 vector<LogicalType> &return_types, vector<CompatName> &names);
 
 	/**
 	 * @brief Global init function for read_yaml
@@ -165,7 +166,7 @@ private:
 	 * @return Function data for execution
 	 */
 	static unique_ptr<FunctionData> YAMLReadObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                    vector<LogicalType> &return_types, vector<string> &names);
+	                                                    vector<LogicalType> &return_types, vector<CompatName> &names);
 
 	/**
 	 * @brief Global init function for read_yaml_objects
@@ -388,7 +389,7 @@ public:
 	 * @return Function data for execution
 	 */
 	static unique_ptr<FunctionData> ParseYAMLBind(ClientContext &context, TableFunctionBindInput &input,
-	                                              vector<LogicalType> &return_types, vector<string> &names);
+	                                              vector<LogicalType> &return_types, vector<CompatName> &names);
 
 	/**
 	 * @brief Init function for parse_yaml local state

--- a/src/yaml_copy.cpp
+++ b/src/yaml_copy.cpp
@@ -259,6 +259,10 @@ void RegisterYAMLCopyFunctions(ExtensionLoader &loader) {
 	    ScalarFunction("copy_format_yaml", {LogicalType::ANY}, LogicalType::VARCHAR, CopyFormatYAMLFunction);
 	CompatSetScalarNullHandling(copy_format_yaml_fun, FunctionNullHandling::SPECIAL_HANDLING);
 	CompatSetScalarVarArgs(copy_format_yaml_fun, LogicalType::ANY); // Allow variable number of arguments
+	// Fallible: this can raise a runtime error on malformed input. DuckDB v2.0
+	// rethrows an execution error from an unmarked function as an INTERNAL error
+	// ("the function must call SetFallible()"). No-op on the pinned v1.5.x.
+	CompatSetFallible(copy_format_yaml_fun);
 	loader.RegisterFunction(copy_format_yaml_fun);
 }
 

--- a/src/yaml_copy.cpp
+++ b/src/yaml_copy.cpp
@@ -28,10 +28,18 @@ static BoundStatement CopyToYAMLPlan(Binder &binder, CopyStatement &stmt) {
 	string yaml_layout = "";    // Default to empty, will infer from style
 	string yaml_multiline = ""; // Default to empty, will resolve to "auto"
 	string yaml_indent = "";    // Default to empty, will use "2"
-	case_insensitive_map_t<vector<Value>> csv_copy_options {{"file_extension", {"yaml"}}};
+	// Typed off CopyInfo::options rather than spelled out: DuckDB v2.0 rekeyed
+	// that map from case_insensitive_map_t<...> (string keys) to
+	// identifier_map_t<...> (Identifier keys), and the two do not assign to each
+	// other. Deriving the local's type from the member it is moved into keeps the
+	// assignment at the bottom of this function correct on both lines, and keeps
+	// working if the map changes again. The literal keys need no helper --
+	// Identifier(const char *) is implicit by design.
+	decltype(copied_info.options) csv_copy_options {{"file_extension", {"yaml"}}};
 
 	for (const auto &kv : copied_info.options) {
-		const auto &loption = StringUtil::Lower(kv.first);
+		// COPY option keys are identifiers on v2.0, so read the raw name out.
+		const auto loption = StringUtil::Lower(CompatIdentifierName(kv.first));
 		if (loption == "style") {
 			if (kv.second.size() != 1) {
 				ThrowYAMLCopyParameterException(loption);

--- a/src/yaml_extraction_functions.cpp
+++ b/src/yaml_extraction_functions.cpp
@@ -711,6 +711,10 @@ void YAMLExtractionFunctions::Register(ExtensionLoader &loader) {
 	yaml_type_set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::VARCHAR, YAMLTypeUnaryFunction));
 	yaml_type_set.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, YAMLTypeBinaryFunction));
+	// Fallible: this can raise a runtime error on malformed input. DuckDB v2.0
+	// rethrows an execution error from an unmarked function as an INTERNAL error
+	// ("the function must call SetFallible()"). No-op on the pinned v1.5.x.
+	CompatSetFallible(yaml_type_set);
 	loader.RegisterFunction(yaml_type_set);
 
 	// yaml_extract function with yaml_extract_path alias
@@ -722,6 +726,11 @@ void YAMLExtractionFunctions::Register(ExtensionLoader &loader) {
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, yaml_type, YAMLExtractFunction));
 
 	// Register yaml_extract and yaml_extract_path alias
+	// Fallible: this can raise a runtime error on malformed input. DuckDB v2.0
+	// rethrows an execution error from an unmarked function as an INTERNAL error
+	// ("the function must call SetFallible()"). No-op on the pinned v1.5.x.
+	CompatSetFallible(yaml_extract_set);
+
 	vector<ScalarFunctionSet> extract_functions;
 	AddAliases({"yaml_extract", "yaml_extract_path"}, yaml_extract_set, extract_functions);
 	for (auto &func : extract_functions) {
@@ -737,6 +746,11 @@ void YAMLExtractionFunctions::Register(ExtensionLoader &loader) {
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, YAMLExtractStringFunction));
 
 	// Register yaml_extract_string, yaml_extract_path_text, and ->> alias
+	// Fallible: this can raise a runtime error on malformed input. DuckDB v2.0
+	// rethrows an execution error from an unmarked function as an INTERNAL error
+	// ("the function must call SetFallible()"). No-op on the pinned v1.5.x.
+	CompatSetFallible(yaml_extract_string_set);
+
 	vector<ScalarFunctionSet> extract_string_functions;
 	AddAliases({"yaml_extract_string", "yaml_extract_path_text", "->>"}, yaml_extract_string_set,
 	           extract_string_functions);
@@ -750,12 +764,17 @@ void YAMLExtractionFunctions::Register(ExtensionLoader &loader) {
 	    ScalarFunction({yaml_type, LogicalType::VARCHAR}, LogicalType::BOOLEAN, YAMLExistsFunction));
 	yaml_exists_set.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN, YAMLExistsFunction));
+	// yaml_exists is deliberately NOT marked fallible: its whole body is inside
+	// catch (...) { return false; }, so it cannot raise. Marking is not free --
+	// `errors` feeds Expression::CanThrow() on the pinned v1.5 too, gating
+	// conjunct reordering and filter pushdown -- so the claim has to be true.
 	loader.RegisterFunction(yaml_exists_set);
 
 	// yaml_structure function - returns JSON representation of YAML structure
 	ScalarFunctionSet yaml_structure_set("yaml_structure");
 	yaml_structure_set.AddFunction(ScalarFunction({yaml_type}, LogicalType::JSON(), YAMLStructureFunction));
 	yaml_structure_set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::JSON(), YAMLStructureFunction));
+	CompatSetFallible(yaml_structure_set);
 	loader.RegisterFunction(yaml_structure_set);
 
 	// yaml_contains function - check if first YAML contains second YAML
@@ -767,6 +786,7 @@ void YAMLExtractionFunctions::Register(ExtensionLoader &loader) {
 	    ScalarFunction({LogicalType::VARCHAR, yaml_type}, LogicalType::BOOLEAN, YAMLContainsFunction));
 	yaml_contains_set.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN, YAMLContainsFunction));
+	CompatSetFallible(yaml_contains_set);
 	loader.RegisterFunction(yaml_contains_set);
 
 	// yaml_merge_patch function - RFC 7386 merge patch
@@ -778,6 +798,7 @@ void YAMLExtractionFunctions::Register(ExtensionLoader &loader) {
 	    ScalarFunction({LogicalType::VARCHAR, yaml_type}, yaml_type, YAMLMergePatchFunction));
 	yaml_merge_patch_set.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, yaml_type, YAMLMergePatchFunction));
+	CompatSetFallible(yaml_merge_patch_set);
 	loader.RegisterFunction(yaml_merge_patch_set);
 
 	// yaml_value function - extract scalar value only, NULL for non-scalars
@@ -786,6 +807,7 @@ void YAMLExtractionFunctions::Register(ExtensionLoader &loader) {
 	    ScalarFunction({yaml_type, LogicalType::VARCHAR}, LogicalType::VARCHAR, YAMLValueFunction));
 	yaml_value_set.AddFunction(
 	    ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::VARCHAR, YAMLValueFunction));
+	CompatSetFallible(yaml_value_set);
 	loader.RegisterFunction(yaml_value_set);
 }
 

--- a/src/yaml_frontmatter.cpp
+++ b/src/yaml_frontmatter.cpp
@@ -124,7 +124,7 @@ static string ReadFileContent(ClientContext &context, const string &file_path) {
 
 // Bind function for read_yaml_frontmatter
 static unique_ptr<FunctionData> YAMLFrontmatterBind(ClientContext &context, TableFunctionBindInput &input,
-                                                    vector<LogicalType> &return_types, vector<string> &names) {
+                                                    vector<LogicalType> &return_types, vector<CompatName> &names) {
 	auto result = make_uniq<YAMLFrontmatterBindData>();
 
 	// Get file paths from first argument
@@ -216,7 +216,7 @@ static unique_ptr<FunctionData> YAMLFrontmatterBind(ClientContext &context, Tabl
 
 		// Add columns in order
 		for (const auto &col : column_order) {
-			names.push_back(col);
+			names.push_back(CompatMakeName(col));
 			return_types.push_back(merged_types[col]);
 		}
 
@@ -228,10 +228,14 @@ static unique_ptr<FunctionData> YAMLFrontmatterBind(ClientContext &context, Tabl
 	} else {
 		// Single frontmatter column as YAML type
 		names.push_back("frontmatter");
-		// Use VARCHAR with YAML alias
-		LogicalType yaml_type = LogicalType::VARCHAR;
-		yaml_type.SetAlias("YAML");
-		return_types.push_back(yaml_type);
+		// Use VARCHAR with YAML alias.
+		// CompatWithAlias, not SetAlias: v2.0 removed LogicalType::SetAlias.
+		// NOTE: the alias here is uppercase "YAML" while YAMLTypes::YAMLType()
+		// (yaml_types.cpp) uses lowercase "yaml", and every GetAlias() check in
+		// this extension compares case-sensitively against "yaml". Preserved
+		// verbatim by this port so the compat change does not move behaviour;
+		// see the PR description for the casing discrepancy.
+		return_types.push_back(CompatWithAlias(LogicalType::VARCHAR, "YAML"));
 	}
 
 	if (result->options.include_content) {
@@ -240,7 +244,7 @@ static unique_ptr<FunctionData> YAMLFrontmatterBind(ClientContext &context, Tabl
 	}
 
 	// Store schema
-	result->names = names;
+	result->names = CompatNameStrings(names);
 	result->types = return_types;
 
 	return std::move(result);

--- a/src/yaml_reader_functions.cpp
+++ b/src/yaml_reader_functions.cpp
@@ -163,7 +163,7 @@ struct YAMLReadBindData : public TableFunctionData {
 };
 
 unique_ptr<FunctionData> YAMLReader::YAMLReadRowsBind(ClientContext &context, TableFunctionBindInput &input,
-                                                      vector<LogicalType> &return_types, vector<string> &names) {
+                                                      vector<LogicalType> &return_types, vector<CompatName> &names) {
 	// Validate primary input
 	if (input.inputs.empty()) {
 		throw BinderException("read_yaml requires a file path parameter");
@@ -351,7 +351,7 @@ unique_ptr<FunctionData> YAMLReader::YAMLReadRowsBind(ClientContext &context, Ta
 						}
 						result->frontmatter_names.push_back(key);
 						result->frontmatter_types.push_back(type);
-						names.push_back(key);
+						names.push_back(CompatMakeName(key));
 						return_types.push_back(type);
 					}
 				}
@@ -381,9 +381,9 @@ unique_ptr<FunctionData> YAMLReader::YAMLReadRowsBind(ClientContext &context, Ta
 			sampled_rows++;
 		}
 		LogicalType list_element_type = DetectJaggedYAMLType(sample_nodes);
-		names.push_back(options.list_column_name);
+		names.push_back(CompatMakeName(options.list_column_name));
 		return_types.push_back(LogicalType::LIST(list_element_type));
-		result->names = names;
+		result->names = CompatNameStrings(names);
 		result->types = return_types;
 		return std::move(result);
 	}
@@ -398,7 +398,7 @@ unique_ptr<FunctionData> YAMLReader::YAMLReadRowsBind(ClientContext &context, Ta
 		} else {
 			throw IOException("No valid YAML documents found");
 		}
-		result->names = names;
+		result->names = CompatNameStrings(names);
 		result->types = return_types;
 		return std::move(result);
 	}
@@ -457,7 +457,7 @@ unique_ptr<FunctionData> YAMLReader::YAMLReadRowsBind(ClientContext &context, Ta
 
 	// Build the final schema in document order
 	for (const auto &col : column_order) {
-		names.push_back(col);
+		names.push_back(CompatMakeName(col));
 		return_types.push_back(detected_types[col]);
 	}
 
@@ -472,7 +472,7 @@ unique_ptr<FunctionData> YAMLReader::YAMLReadRowsBind(ClientContext &context, Ta
 	}
 
 	// Save schema
-	result->names = names;
+	result->names = CompatNameStrings(names);
 	result->types = return_types;
 
 	return std::move(result);
@@ -513,7 +513,7 @@ OperatorPartitionData YAMLReader::YAMLReadGetPartitionData(ClientContext &contex
 }
 
 unique_ptr<FunctionData> YAMLReader::YAMLReadObjectsBind(ClientContext &context, TableFunctionBindInput &input,
-                                                         vector<LogicalType> &return_types, vector<string> &names) {
+                                                         vector<LogicalType> &return_types, vector<CompatName> &names) {
 	// Validate primary input
 	if (input.inputs.empty()) {
 		throw BinderException("read_yaml_objects requires a file path parameter");
@@ -621,19 +621,19 @@ unique_ptr<FunctionData> YAMLReader::YAMLReadObjectsBind(ClientContext &context,
 
 	if (sample_docs.empty()) {
 		if (!options.column_names.empty()) {
-			names = options.column_names;
+			names = CompatMakeNames(options.column_names);
 			return_types = options.column_types;
 		} else {
 			names.emplace_back("yaml");
 			return_types.emplace_back(LogicalType::VARCHAR);
 		}
-		result->names = names;
+		result->names = CompatNameStrings(names);
 		result->types = return_types;
 		return std::move(result);
 	}
 
 	if (!options.column_names.empty()) {
-		names = options.column_names;
+		names = CompatMakeNames(options.column_names);
 		return_types = options.column_types;
 	} else {
 		if (options.auto_detect_types) {
@@ -646,7 +646,7 @@ unique_ptr<FunctionData> YAMLReader::YAMLReadObjectsBind(ClientContext &context,
 		}
 	}
 
-	result->names = names;
+	result->names = CompatNameStrings(names);
 	result->types = return_types;
 	return std::move(result);
 }
@@ -1070,7 +1070,7 @@ struct ParseYAMLLocalState : public LocalTableFunctionState {
 };
 
 unique_ptr<FunctionData> YAMLReader::ParseYAMLBind(ClientContext &context, TableFunctionBindInput &input,
-                                                   vector<LogicalType> &return_types, vector<string> &names) {
+                                                   vector<LogicalType> &return_types, vector<CompatName> &names) {
 	if (input.inputs.empty()) {
 		throw BinderException("parse_yaml requires a YAML string parameter");
 	}
@@ -1121,7 +1121,7 @@ unique_ptr<FunctionData> YAMLReader::ParseYAMLBind(ClientContext &context, Table
 		// Empty result - return a single yaml column
 		names.emplace_back("yaml");
 		return_types.emplace_back(LogicalType::VARCHAR);
-		result->names = names;
+		result->names = CompatNameStrings(names);
 		result->types = return_types;
 		return std::move(result);
 	}
@@ -1133,7 +1133,7 @@ unique_ptr<FunctionData> YAMLReader::ParseYAMLBind(ClientContext &context, Table
 		// Struct type - use struct fields as columns
 		auto &children = StructType::GetChildTypes(merged_type);
 		for (auto &child : children) {
-			names.push_back(CompatIdentifierName(child.first));
+			names.push_back(CompatMakeName(CompatIdentifierName(child.first)));
 			return_types.push_back(child.second);
 		}
 	} else {
@@ -1142,7 +1142,7 @@ unique_ptr<FunctionData> YAMLReader::ParseYAMLBind(ClientContext &context, Table
 		return_types.emplace_back(merged_type);
 	}
 
-	result->names = names;
+	result->names = CompatNameStrings(names);
 	result->types = return_types;
 	return std::move(result);
 }

--- a/src/yaml_scalar_functions.cpp
+++ b/src/yaml_scalar_functions.cpp
@@ -290,6 +290,14 @@ void YAMLFunctions::RegisterYAMLTypeFunctions(ExtensionLoader &loader) {
 	    ScalarFunction("format_yaml", {LogicalType::ANY}, LogicalType::VARCHAR, FormatYAMLFunction, FormatYAMLBind);
 	CompatSetScalarNullHandling(format_yaml_fun, FunctionNullHandling::SPECIAL_HANDLING);
 	CompatSetScalarVarArgs(format_yaml_fun, LogicalType::ANY); // Allow variable number of arguments
+	// format_yaml derives its named parameters (style := ..., multiline := ...,
+	// indent := ...) from argument ALIASES, both in FormatYAMLBind and in
+	// FormatYAMLFunction. DuckDB v2.0 stopped capturing those aliases unless the
+	// function opts in (FunctionProperties::capture_argument_aliases defaults to
+	// false), which would make every named argument arrive anonymous and every
+	// format_yaml(x, style := 'block') call throw at bind time -- with a green
+	// build. No-op on the pinned v1.5.x, where capture was unconditional.
+	CompatSetCaptureArgumentAliases(format_yaml_fun);
 	loader.RegisterFunction(format_yaml_fun);
 
 	// Register yaml() constructor function (parses YAML string to YAML type)

--- a/src/yaml_scalar_functions.cpp
+++ b/src/yaml_scalar_functions.cpp
@@ -57,6 +57,10 @@ void YAMLFunctions::RegisterValidationFunction(ExtensionLoader &loader) {
 		                                                                      [&](string_t yaml_str) { return true; });
 	                               });
 
+	// Deliberately NOT marked fallible: both overloads are total. The VARCHAR one
+	// wraps the parse in catch(...) and answers false; the YAML one is a constant
+	// true. Marking a function fallible is only a lost optimisation, but marking
+	// one that cannot throw is still a claim worth not making.
 	loader.RegisterFunction(yaml_valid_varchar);
 	loader.RegisterFunction(yaml_valid_yaml);
 }
@@ -275,10 +279,18 @@ void YAMLFunctions::RegisterYAMLTypeFunctions(ExtensionLoader &loader) {
 
 	// Register yaml_to_json function
 	auto yaml_to_json_fun = ScalarFunction("yaml_to_json", {yaml_type}, LogicalType::JSON(), YAMLToJSONFunction);
+	// Fallible: raises a runtime error on malformed input or an oversized document.
+	// DuckDB v2.0 rethrows an execution error from an unmarked function as an
+	// INTERNAL error ("the function must call SetFallible()"). Enforcement is an
+	// assertion, so a canary leg built without assertions can be green while the
+	// contract is violated. No-op on the pinned v1.5.x.
+	CompatSetFallible(yaml_to_json_fun);
 	loader.RegisterFunction(yaml_to_json_fun);
 
 	// Register value_to_yaml function and to_yaml alias (single parameter, returns YAML type)
 	auto value_to_yaml_fun = ScalarFunction("value_to_yaml", {LogicalType::ANY}, yaml_type, ValueToYAMLFunction);
+	// value_to_yaml / to_yaml are deliberately NOT marked: ValueToYAMLFunction
+	// catches std::exception and (...) per row and substitutes "null".
 	loader.RegisterFunction(value_to_yaml_fun);
 
 	// to_yaml alias for consistency with to_json
@@ -298,6 +310,7 @@ void YAMLFunctions::RegisterYAMLTypeFunctions(ExtensionLoader &loader) {
 	// format_yaml(x, style := 'block') call throw at bind time -- with a green
 	// build. No-op on the pinned v1.5.x, where capture was unconditional.
 	CompatSetCaptureArgumentAliases(format_yaml_fun);
+	CompatSetFallible(format_yaml_fun);
 	loader.RegisterFunction(format_yaml_fun);
 
 	// Register yaml() constructor function (parses YAML string to YAML type)
@@ -316,6 +329,7 @@ void YAMLFunctions::RegisterYAMLTypeFunctions(ExtensionLoader &loader) {
 			    }
 		    });
 	    });
+	CompatSetFallible(yaml_constructor_fun);
 	loader.RegisterFunction(yaml_constructor_fun);
 }
 
@@ -362,10 +376,12 @@ void YAMLFunctions::RegisterStyleFunctions(ExtensionLoader &loader) {
 	// Register default style management functions
 	auto yaml_set_default_style_fun = ScalarFunction("yaml_set_default_style", {LogicalType::VARCHAR},
 	                                                 LogicalType::VARCHAR, YAMLSetDefaultStyleFunction);
+	CompatSetFallible(yaml_set_default_style_fun); // rejects NULL and unknown styles
 	loader.RegisterFunction(yaml_set_default_style_fun);
 
 	auto yaml_get_default_style_fun =
 	    ScalarFunction("yaml_get_default_style", {}, LogicalType::VARCHAR, YAMLGetDefaultStyleFunction);
+	// yaml_get_default_style is total -- a pure read of the current setting.
 	loader.RegisterFunction(yaml_get_default_style_fun);
 
 	RegisterLimitFunctions(loader);
@@ -383,21 +399,26 @@ void YAMLFunctions::RegisterStyleFunctions(ExtensionLoader &loader) {
 // takes a std::string. A string literal converts implicitly to both; std::string does not.
 template <void (*SETTER)(idx_t), idx_t (*GETTER)()>
 static ScalarFunction MakeLimitSetter(const char *name) {
-	return ScalarFunction(name, {LogicalType::BIGINT}, LogicalType::BIGINT,
-	                      [](DataChunk &args, ExpressionState &state, Vector &result) {
-		                      UnaryExecutor::Execute<int64_t, int64_t>(
-		                          args.data[0], result, args.size(), [&](int64_t value) -> int64_t {
-			                          if (value < 1) {
-				                          throw InvalidInputException("YAML limit must be a positive value");
-			                          }
-			                          SETTER(static_cast<idx_t>(value));
-			                          return static_cast<int64_t>(GETTER());
-		                          });
-	                      });
+	auto fun = ScalarFunction(
+	    name, {LogicalType::BIGINT}, LogicalType::BIGINT, [](DataChunk &args, ExpressionState &state, Vector &result) {
+		    UnaryExecutor::Execute<int64_t, int64_t>(args.data[0], result, args.size(), [&](int64_t value) -> int64_t {
+			    if (value < 1) {
+				    throw InvalidInputException("YAML limit must be a positive value");
+			    }
+			    SETTER(static_cast<idx_t>(value));
+			    return static_cast<int64_t>(GETTER());
+		    });
+	    });
+	// Fallible: rejects non-positive limits at execution time. Marked here, before
+	// the function is handed to the loader, because on DuckDB v2.0 a function is
+	// immutable once it has been added to a set. No-op on the pinned v1.5.x.
+	CompatSetFallible(fun);
+	return fun;
 }
 
 // Build a getter scalar function (no arguments) returning the current limit.
-// See MakeLimitSetter for why `name` is `const char *`.
+// See MakeLimitSetter for why `name` is `const char *`. Not marked fallible:
+// a getter is a pure read and cannot raise.
 template <idx_t (*GETTER)()>
 static ScalarFunction MakeLimitGetter(const char *name) {
 	return ScalarFunction(name, {}, LogicalType::BIGINT,
@@ -512,12 +533,14 @@ void YAMLFunctions::RegisterFromYAMLFunction(ExtensionLoader &loader) {
 	auto from_yaml_fun =
 	    ScalarFunction("from_yaml", {yaml_type, LogicalType::ANY}, LogicalType::ANY, FromYAMLFunction, FromYAMLBind);
 	CompatSetScalarNullHandling(from_yaml_fun, FunctionNullHandling::SPECIAL_HANDLING);
+	CompatSetFallible(from_yaml_fun);
 	loader.RegisterFunction(from_yaml_fun);
 
 	// Also register version that takes VARCHAR input
 	auto from_yaml_varchar_fun = ScalarFunction("from_yaml", {LogicalType::VARCHAR, LogicalType::ANY}, LogicalType::ANY,
 	                                            FromYAMLFunction, FromYAMLBind);
 	CompatSetScalarNullHandling(from_yaml_varchar_fun, FunctionNullHandling::SPECIAL_HANDLING);
+	CompatSetFallible(from_yaml_varchar_fun);
 	loader.RegisterFunction(from_yaml_varchar_fun);
 }
 

--- a/src/yaml_types.cpp
+++ b/src/yaml_types.cpp
@@ -1,4 +1,5 @@
 #include "yaml_types.hpp"
+#include "duckdb_compat.hpp"
 #include "yaml_utils.hpp"
 #include "yaml_formatting.hpp"
 #include "yaml-cpp/yaml.h"
@@ -10,9 +11,12 @@ namespace duckdb {
 //===--------------------------------------------------------------------===//
 
 LogicalType YAMLTypes::YAMLType() {
-	auto yaml_type = LogicalType(LogicalTypeId::VARCHAR);
-	yaml_type.SetAlias("yaml");
-	return yaml_type;
+	// CompatWithAlias, not SetAlias: DuckDB v2.0 REMOVED LogicalType::SetAlias in
+	// favour of WithAlias(), which returns a copy rather than mutating a type
+	// whose type-info may be shared. The alias string is lowercase "yaml" and
+	// must stay that way -- IsYAMLType() below and the checks in
+	// yaml_reader_types.cpp compare GetAlias() against "yaml" case-sensitively.
+	return CompatWithAlias(LogicalType(LogicalTypeId::VARCHAR), "yaml");
 }
 
 static bool IsYAMLType(const LogicalType &t) {

--- a/src/yaml_unnest_functions.cpp
+++ b/src/yaml_unnest_functions.cpp
@@ -190,11 +190,14 @@ static void YAMLKeysUnaryFunction(DataChunk &args, ExpressionState &state, Vecto
 				    keys.push_back(Value(key));
 			    }
 
-			    // Get the list child vector. const_cast on the data pointer: on duckdb
-			    // main FlatVector::GetData<T> returns const T*, on v1.5.x non-const —
-			    // the cast is a no-op on the old API and the right strip on the new one.
+			    // Get the list child vector. CompatFlatDataMutable, not a const_cast:
+			    // on DuckDB v2.0 FlatVector::GetData<T> returns const T* and the
+			    // mutable accessor goes through Vector::BufferMutable(), which
+			    // un-shares a copy-on-write buffer first. Casting away the const
+			    // would compile but write into a buffer that may still be shared
+			    // with another vector. No-op on the pinned v1.5.x.
 			    auto &child_vector = ListVector::GetEntry(result);
-			    auto list_data = const_cast<string_t *>(FlatVector::GetData<string_t>(child_vector));
+			    auto list_data = CompatFlatDataMutable<string_t>(child_vector);
 
 			    list_entry_t entry;
 			    entry.offset = ListVector::GetListSize(result);
@@ -237,9 +240,9 @@ static void YAMLKeysBinaryFunction(DataChunk &args, ExpressionState &state, Vect
 				    keys.push_back(Value(key));
 			    }
 
-			    // const_cast: see comment in YAMLKeysUnaryFunction above.
+			    // CompatFlatDataMutable: see comment in YAMLKeysUnaryFunction above.
 			    auto &child_vector = ListVector::GetEntry(result);
-			    auto list_data = const_cast<string_t *>(FlatVector::GetData<string_t>(child_vector));
+			    auto list_data = CompatFlatDataMutable<string_t>(child_vector);
 
 			    list_entry_t entry;
 			    entry.offset = ListVector::GetListSize(result);
@@ -268,7 +271,7 @@ struct YAMLArrayElementsBindData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> YAMLArrayElementsBind(ClientContext &context, TableFunctionBindInput &input,
-                                                      vector<LogicalType> &return_types, vector<string> &names) {
+                                                      vector<LogicalType> &return_types, vector<CompatName> &names) {
 	if (input.inputs.empty()) {
 		throw BinderException("yaml_array_elements requires a YAML array parameter");
 	}
@@ -343,7 +346,7 @@ struct YAMLEachBindData : public TableFunctionData {
 };
 
 static unique_ptr<FunctionData> YAMLEachBind(ClientContext &context, TableFunctionBindInput &input,
-                                             vector<LogicalType> &return_types, vector<string> &names) {
+                                             vector<LogicalType> &return_types, vector<CompatName> &names) {
 	if (input.inputs.empty()) {
 		throw BinderException("yaml_each requires a YAML object parameter");
 	}

--- a/src/yaml_unnest_functions.cpp
+++ b/src/yaml_unnest_functions.cpp
@@ -659,6 +659,10 @@ void YAMLUnnestFunctions::Register(ExtensionLoader &loader) {
 	yaml_array_length_set.AddFunction(ScalarFunction({yaml_type}, LogicalType::BIGINT, YAMLArrayLengthUnaryFunction));
 	yaml_array_length_set.AddFunction(
 	    ScalarFunction({yaml_type, LogicalType::VARCHAR}, LogicalType::BIGINT, YAMLArrayLengthBinaryFunction));
+	// Fallible: this can raise a runtime error on malformed input. DuckDB v2.0
+	// rethrows an execution error from an unmarked function as an INTERNAL error
+	// ("the function must call SetFallible()"). No-op on the pinned v1.5.x.
+	CompatSetFallible(yaml_array_length_set);
 	loader.RegisterFunction(yaml_array_length_set);
 
 	// yaml_keys function
@@ -667,6 +671,7 @@ void YAMLUnnestFunctions::Register(ExtensionLoader &loader) {
 	    ScalarFunction({yaml_type}, LogicalType::LIST(LogicalType::VARCHAR), YAMLKeysUnaryFunction));
 	yaml_keys_set.AddFunction(ScalarFunction({yaml_type, LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR),
 	                                         YAMLKeysBinaryFunction));
+	CompatSetFallible(yaml_keys_set);
 	loader.RegisterFunction(yaml_keys_set);
 
 	// yaml_array_elements table function
@@ -681,6 +686,7 @@ void YAMLUnnestFunctions::Register(ExtensionLoader &loader) {
 	// yaml_build_object function - variadic function
 	auto yaml_build_object_fun = ScalarFunction("yaml_build_object", {}, yaml_type, YAMLBuildObjectFunction);
 	CompatSetScalarVarArgs(yaml_build_object_fun, LogicalType::ANY);
+	CompatSetFallible(yaml_build_object_fun);
 	loader.RegisterFunction(yaml_build_object_fun);
 
 	// yaml_agg aggregate function
@@ -692,6 +698,9 @@ void YAMLUnnestFunctions::Register(ExtensionLoader &loader) {
 	                      nullptr, // bind
 	                      nullptr  // destructor
 	    );
+	// The aggregate re-parses and re-emits YAML in its finalize, so it can raise
+	// a runtime error too; BaseAggregateFunction carries the same contract.
+	CompatSetFallible(yaml_agg_fun);
 	loader.RegisterFunction(yaml_agg_fun);
 }
 


### PR DESCRIPTION
## What

Makes the extension compile against **both** the pinned DuckDB v1.5.4 it ships
against **and** DuckDB `main` (the v2.0 / `v2.0-cyanoptera` line). This is
source compatibility, not a migration — the submodule stays pinned and the
shipped binary is unchanged.

The motivation is `duckdb/community-extensions`' `build_next.yml`, which builds
every release PR against `v2.0-cyanoptera` and has no per-extension opt-out. An
extension that does not compile there shows a red check on every release.

## How

Everything goes through `src/include/duckdb_compat.hpp`, which is **added to,
not replaced** — the existing v1.4-era vector/bind shims and the
scalar-function/expression accessors are untouched and all their call sites
still work.

Every new shim is a **feature probe**, never a version macro, and every probe
points at the member that exists **only on v2.0**. That polarity matters: v2.0
*deprecated* rather than deleted several APIs, so a probe aimed at the member
being replaced is true on both versions and would silently never take the new
branch.

### New shims

| shim | change it covers |
|---|---|
| `CompatName` / `CompatNameStr` / `CompatMakeName` / `CompatNameStrings` / `CompatMakeNames` | `table_function_bind_t` now takes `vector<Identifier> &names` |
| `CompatWithAlias` | `LogicalType::SetAlias` **removed** in favour of `WithAlias()` |
| `CompatFlatDataMutable` | `FlatVector::GetData<T>` is const-only; writes need `GetDataMutable<T>` |
| `CompatFlatValidityMutable` | `FlatVector::Validity` took the same const split |
| `CompatSetCaptureArgumentAliases` | `FunctionProperties::capture_argument_aliases` now defaults to **false** |
| `CompatSetFallible` | a function that can throw at execution time must now declare it |

The bind-name helpers are kept deliberately **separate** from the existing
`CompatIdentifierName` / `CompatMakeIdentifier`, which serve the `child_list_t`
(STRUCT field name) and function/expression-name boundary. Both are driven by
the same upstream `Identifier` type, but they are distinct call sites; merging
them would couple two things that can move independently.

`CompatWithAlias`'s entry point is deliberately **not** a deduced template.
`LogicalType::VARCHAR` is a `LogicalTypeId` constant, so a deduced parameter
binds `TYPE = LogicalTypeId` and then hard-errors inside the shim
(`request for member 'SetAlias' in 'type', which is of non-class type
'duckdb::LogicalTypeId'`). A concrete `LogicalType` parameter puts the usual
implicit conversion back at the call site. The tag-dispatch `Impl` overloads
stay templated so only the selected branch is ever instantiated — this
extension builds at `-std=c++11` on purpose, so `if constexpr` is not
available.

### Call sites

* **`SetAlias` → `CompatWithAlias`** — `yaml_types.cpp` (`YAMLTypes::YAMLType()`)
  and `yaml_frontmatter.cpp`. Alias casing preserved **verbatim**; see the note
  below.
* **Bind signatures** take `vector<CompatName> &names`, in both declarations and
  definitions: `read_yaml`, `read_yaml_objects`, `parse_yaml`,
  `read_yaml_frontmatter`, `yaml_array_elements`, `yaml_each`. Bind *data* keeps
  plain `vector<string>` (it is compared and sliced with string operations
  downstream), so the two vectors are converted rather than assigned. Column
  names built at **runtime** from YAML keys go through `CompatMakeName`;
  literals are unchanged, since `Identifier(const char *)` is implicit by
  design.
* **`format_yaml` opts back into argument-alias capture.** It derives
  `style :=`, `multiline :=` and `indent :=` from argument *aliases*, in both
  `FormatYAMLBind` and `FormatYAMLFunction`. On v2.0 those aliases are not
  recorded unless the function asks, so every named argument would arrive
  anonymous and every call would throw `Need named argument for format_yaml` —
  **with a completely green build**. DuckDB's own `struct_pack`/`row` call
  `SetCaptureArgumentAliases(true)` for exactly this reason
  (`src/function/scalar/struct/struct_pack.cpp`). Covered by the existing
  `test/sql/yaml_types/yaml_format_parameter.test`.
* **`yaml_keys` list-child writes** use `CompatFlatDataMutable` instead of
  `const_cast`. This is a **correctness fix, not a style change**: on v2.0
  `GetDataMutable` routes through `Vector::BufferMutable()`, which un-shares a
  copy-on-write buffer first, while the plain `GetData` path does not. Casting
  away the const compiles and then writes into a buffer that may still be
  shared with another vector.

### Deliberately not changed

`yaml_copy.cpp`'s three `SetAlias` calls need nothing. Only
`LogicalType::SetAlias` was removed — `BaseExpression::SetAlias` still exists on
v2.0, it just takes an `Identifier` (implicit from a literal), and
`BoundStatement::names` is already `vector<Identifier>` there, so
`column->SetAlias(bound_original.names[i])` compiles unchanged on both
versions. A grep for `SetAlias` finds both kinds; only one is a break.

Likewise `Vector::ToUnifiedFormat(count, data)`, `DataChunk::SetCardinality`
and `ConstantVector::GetData<T>` are deprecated-but-present on v2.0 and are left
alone. `yaml_extraction_functions.cpp`'s `AddAliases(const vector<string> &)`
takes **function** alias names, not column names, and stays `string`.


## Two silent runtime breaks (no compile error, nothing to grep in the API)

These are the ones a green build does not cover, and the only defence is a test
that exercises the path.

**Argument aliases.** `format_yaml` derives `style :=`, `multiline :=` and
`indent :=` from argument *aliases*, in both its bind and its execute. v2.0
stopped recording those unless a function opts in
(`capture_argument_aliases` defaults to false), so every named argument would
arrive anonymous and every call would throw `Need named argument for
format_yaml` — on a completely green build. DuckDB's own `struct_pack`/`row`
opt in for the same reason
(`src/function/scalar/struct/struct_pack.cpp`). Covered by the existing
`test/sql/yaml_types/yaml_format_parameter.test`.

**Fallibility.** v2.0 rethrows an execution error from an unmarked scalar
function as `INTERNAL Error: ... the function must call SetFallible()`.

This one is **not** a v2.0-only concept, and the shim is **not** a no-op on the
version we ship. `BaseScalarFunction::SetFallible()` exists on v1.5.4 too, and
`errors` feeds `Expression::CanThrow()`, which gates conjunct reordering, filter
pushdown and dictionary caching. v2.0 only added *enforcement* of a contract
this extension was already violating — so this is a latent correctness fix on
the pinned version, not just forward compatibility.

Because it is optimizer-visible on the shipped binary, the marking is precise
rather than blanket. 18 of 21 registered scalar functions are marked. Three are
deliberately left alone because their throwing code is **unreachable**, which a
`throw` grep does not show:

| function | why it cannot raise |
|---|---|
| `yaml_exists` | whole body inside `catch (...) { return false; }` |
| `value_to_yaml` / `to_yaml` | per-row `catch` substitutes `"null"` |
| `yaml_valid` | same, plus a constant-`true` overload |

The tell is a catch-all that **returns** rather than rethrows. `yaml_contains`
looks identical until you reach `catch (const InvalidInputException &) { throw; }`
— that one *is* fallible.

A shim is needed only for the `FunctionSet` case, and its two branches are not
"old vs new" but "function vs v1.5 set": the pinned `FunctionSet` has no
set-level `SetFallible` but its `vector<T> functions` members are still mutable,
while v2.0 added a set-level setter precisely because its members became
`shared_ptr<const T>`.

## The probe that was a time bomb

`__has_include("duckdb/common/identifier.hpp")` is the obvious way to select
`CompatName`, and it is wrong — not today, but on the next submodule bump.
`identifier.hpp` has already been **backported to the stable branch** without
the bind signature changing:

| head | identifier.hpp | bind signature |
|---|---|---|
| `v1.5-variegata` @ `b155d6f63c` (our pin) | absent | `vector<string>` |
| `v1.5-variegata` @ branch tip | **present** | `vector<string>` |
| `main` (v2.0) | present | `vector<Identifier>` |

The header probe agrees with reality only because our pin predates the
backport. `CompatName` is now derived from the boundary itself — the element
type of `TableFunctionBindInput::input_table_names`, which matches the bind
out-parameter on both lines — so it is exact by construction rather than by
correlation. `__has_include` is kept only to gate whether an `Identifier`
*overload* can be declared; it no longer decides any type.

The pre-existing `CompatMakeIdentifier` had the identical latent bug and is
fixed the same way, deriving from `child_list_t<LogicalType>`'s key type
(verified `std::string` on both the pin *and* the v1.5 tip, `Identifier` on
`main`). Neither derivation uses `typename`: both name non-dependent types, and
`typename` outside a template is only valid from C++20, which the Windows MSVC
leg would reject.


### `CompatSetOutputCardinality` audited and deliberately left alone

Worth recording, because the obvious reading of upstream's warning gives the
wrong answer here. `DataChunk::SetCardinality` is deprecated on v2.0 in favour
of `SetChildCardinality`, and `data_chunk.hpp` warns that callers who "mutate
the child vectors directly ... and then call SetCardinality" would have their
data resized/overwritten by the new call. All 11 of this extension's
cardinality calls do come *after* the writes, so this looks like a hit.

It is not, and the discriminator is **which write API**, not the order:

| write API | effect on child `v_size` | correct on v2.0 |
|---|---|---|
| `Vector::Append` / `AppendValue` | advances it as you go | `SetCardinalityUnsafe` — `SetChildCardinality` would truncate |
| `DataChunk::SetValue` / `Vector::SetValue` | leaves it at 0 after `Reset()` | **`SetChildCardinality`** |

Traced on `main`: `Vector::SetValue` forwards to `buffer->SetValue(type, index, val)`,
which writes at an index and never touches `v_size`; `VectorBuffer::AppendValue`
is the one that does `SetVectorSize(v_size + 1)`. `DataChunk::Reset()` leaves
`count` unset and the children at size 0, and `SetVectorSize` is a pure size
setter (bounds-checked, no realloc, no zeroing). So after `Reset()` + N ×
`SetValue`, `SetChildCardinality(N)` is the only call that brings the children
up to N — `SetCardinalityUnsafe(N)` would leave them at 0 and the next
`CheckCardinality` would throw *"vector has size 0 but expected size N"*.

This extension uses `DataChunk::SetValue` at all 11 sites and has zero
`Vector::Append` (`grep -rn '\.Append(\|AppendValue' src/` is empty), so the
existing shim is already correct and is unchanged.


## COPY option maps were rekeyed, not just the bind signature

Found by the canary rather than by reading. `CopyInfo::options` went from
`case_insensitive_map_t<vector<Value>>` to `identifier_map_t<vector<Value>>`:

```
yaml_copy.cpp:34   cannot convert 'const duckdb::Identifier' to 'const string&'
yaml_copy.cpp:180  no match for 'operator=' between identifier_map_t<...>
                   and case_insensitive_map_t<...>
```

The first is the ordinary "option keys are identifiers" case. The second is the
one nothing finds: this file declared its **own**
`case_insensitive_map_t<vector<Value>>` local and moved it into
`copied_info.options`, so there is no `option.first` near the declaration and
the compiler only complains 150 lines later at the assignment.

Fixed by deriving the local's type from the member it is moved into
(`decltype(copied_info.options)`) rather than spelling either type out — no
shim, no `#ifdef`, and it survives the next rekey. The literal keys are
unchanged.

## CI

The `duckdb-next-build` canary is renamed to **DuckDB main canary** and gated to
`workflow_dispatch` / pushes to `main`. It was previously ungated: `push` and
`pull_request` both fire on the same commit and a PR's check rollup includes
both, so a job that *intentionally* tracks upstream API drift made every PR look
broken.

This is an `if:` and deliberately **not** a `continue-on-error:` — a job that
calls a **reusable** workflow accepts only a fixed key set, and adding
`continue-on-error` makes the whole file fail to parse, scheduling zero jobs
including the shippable build.

## Latent bug found, reported not fixed

`read_yaml_frontmatter(..., as_yaml_objects := true)` labels its `frontmatter`
column with the alias **`YAML`** (uppercase), while `YAMLTypes::YAMLType()` uses
**`yaml`** (lowercase) and every `GetAlias()` check in the extension compares
case-sensitively. These are two *separate* `LogicalType` objects, so neither
`SetAlias` call was overwriting the other — but the column ends up being a
different type from the registered one:

```
D SELECT yaml_type(frontmatter) FROM read_yaml_frontmatter('...', as_yaml_objects := true);
Binder Error: No function matches the given name and argument types 'yaml_type(YAML)'.
	Candidate functions:
	yaml_type(yaml) -> VARCHAR
	...
```

`ExtraTypeInfo::alias` is a plain `string` on v2.0 too, so this behaves
identically on both versions — it is pre-existing, not introduced here. It is
also **pinned by a test** (`yaml_frontmatter_reader.test` asserts `YAML`), so
fixing it means changing behaviour and a test expectation together. Out of
scope for a source-compat PR; filed here so it is not lost.

## Verification

* Full suite against the pinned v1.5.4: **all tests passed, 1764 assertions in
  49 test cases** (3 skipped, `require httpfs`).
* `-fsyntax-only` across all 16 extension TUs against the pinned DuckDB: clean.
* No new `clang-format` drift relative to `main` (measured per changed file;
  the pre-existing drift on `main` is untouched).
* v2.0 half: canary run `33836890091` compiled 15 of 16 TUs clean against
  DuckDB `main` and caught the COPY-options rekey above as the only failure;
  every shim in this PR held. A re-run is queued to confirm the fix **and to
  reach the Test step**, which the failed Build skipped — and Test is the only
  thing that can verify the two silent-runtime classes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoHU19qnngy1CJnXyX1csz