### PR TITLE
fix: frontmatter opening delimiter and invalid-YAML cast lose data silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ Frontmatter works with any text file that uses `---` delimiters:
 
 Schemas are automatically merged across files with different frontmatter fields (jagged schema support). Columns not present in a file will have `NULL` values.
 
+**Delimiters.** The opening delimiter must be a line containing exactly `---` (trailing
+spaces or tabs are allowed) as the very first line of the file; a leading UTF-8 BOM is
+skipped. A line that merely *starts* with three dashes — a markdown thematic break such as
+`----`, or `---foo` — does not open a frontmatter block, so an ordinary markdown file that
+opens with a horizontal rule is correctly treated as having no frontmatter. The block is
+closed by the next `---` or `...` line at column 0; a `---` indented inside a block scalar
+is scalar content and does not close it. Files with no frontmatter, and files whose
+frontmatter block is empty, produce no rows.
+
 #### Example: Analyzing a Blog
 
 ```sql

--- a/src/yaml_frontmatter.cpp
+++ b/src/yaml_frontmatter.cpp
@@ -68,8 +68,13 @@ static bool IsDelimiterLine(const string &content, size_t pos, bool allow_docume
 static pair<string, string> ExtractFrontmatter(const string &content) {
 	// A UTF-8 BOM is common in Windows-authored markdown. Without skipping it the opening
 	// delimiter never matches and the file silently yields no frontmatter at all, even
-	// though it has some (issue #42). Every other frontmatter reader (Jekyll, gray-matter,
-	// python-frontmatter) strips the BOM before looking for the delimiter.
+	// though it has some (issue #42). MEASURED against the other readers 2026-09-07 rather
+	// than assumed: Jekyll strips it (Utils.merged_file_read_opts prepends "bom|" to any
+	// utf- encoding, so Ruby drops it at read time) and so does gray-matter; but
+	// python-frontmatter does NOT -- its `^-{3,}\s*$` boundary simply fails and a BOM'd file
+	// comes back with no metadata. Stripping is the majority behaviour and the only one that
+	// does not lose data, and it is what duckdb_markdown's SkipBOM already did, so the two
+	// extensions agree about the same file.
 	size_t origin = 0;
 	if (content.size() >= 3 && content.compare(0, 3, "\xEF\xBB\xBF") == 0) {
 		origin = 3;

--- a/src/yaml_frontmatter.cpp
+++ b/src/yaml_frontmatter.cpp
@@ -30,25 +30,70 @@ struct YAMLFrontmatterLocalState : public LocalTableFunctionState {
 	idx_t current_file = 0;
 };
 
+// True if a standalone frontmatter delimiter line begins at `pos`: exactly "---" (or
+// "..." when `allow_document_end`) followed by nothing but spaces/tabs to the end of the
+// line or the end of the input.
+//
+// Both the opening and the closing delimiter go through this so they cannot disagree.
+// They used to: the opening test was a bare `content.substr(0, 3) == "---"` prefix match,
+// so a plain markdown file whose first line was a thematic break (`----`, `-----`) or any
+// `---foo` was treated as opening a frontmatter block. Everything up to the next `---`
+// line was then swallowed as "frontmatter" -- which parses to nothing -- and only the tail
+// was returned as the body, truncating the document with no error (issue #42). The closing
+// test, meanwhile, already required a full-line match, so `----` opened a block that could
+// never be closed by another `----`.
+static bool IsDelimiterLine(const string &content, size_t pos, bool allow_document_end) {
+	if (pos + 3 > content.size()) {
+		return false;
+	}
+	bool is_marker = content.compare(pos, 3, "---") == 0 || (allow_document_end && content.compare(pos, 3, "...") == 0);
+	if (!is_marker) {
+		return false;
+	}
+	for (size_t i = pos + 3; i < content.size(); i++) {
+		const char c = content[i];
+		if (c == '\n' || c == '\r') {
+			return true;
+		}
+		if (c != ' ' && c != '\t') {
+			return false;
+		}
+	}
+	return true; // delimiter runs to the end of the input
+}
+
 // Extract frontmatter from file content
 // Returns a pair of (frontmatter_yaml, body_content)
 // If no frontmatter found, returns empty frontmatter
 static pair<string, string> ExtractFrontmatter(const string &content) {
-	// Frontmatter must start with "---" at the beginning of the file
-	if (content.size() < 3 || content.substr(0, 3) != "---") {
-		return {"", content};
+	// A UTF-8 BOM is common in Windows-authored markdown. Without skipping it the opening
+	// delimiter never matches and the file silently yields no frontmatter at all, even
+	// though it has some (issue #42). Every other frontmatter reader (Jekyll, gray-matter,
+	// python-frontmatter) strips the BOM before looking for the delimiter.
+	size_t origin = 0;
+	if (content.size() >= 3 && content.compare(0, 3, "\xEF\xBB\xBF") == 0) {
+		origin = 3;
+	}
+	auto without_frontmatter = [&]() -> pair<string, string> {
+		return {"", origin == 0 ? content : content.substr(origin)};
+	};
+
+	// Frontmatter must open with a "---" line at the very beginning of the file. "..." is a
+	// document *end* marker and never opens a block.
+	if (!IsDelimiterLine(content, origin, /*allow_document_end=*/false)) {
+		return without_frontmatter();
 	}
 
-	// Find the end delimiter (--- or ...)
-	size_t start = 3;
-	// Skip whitespace/newline after opening ---
+	// Move past the opening delimiter line.
+	size_t start = origin + 3;
 	while (start < content.size() && (content[start] == ' ' || content[start] == '\t')) {
+		start++;
+	}
+	if (start < content.size() && content[start] == '\r') {
 		start++;
 	}
 	if (start < content.size() && content[start] == '\n') {
 		start++;
-	} else if (start + 1 < content.size() && content[start] == '\r' && content[start + 1] == '\n') {
-		start += 2;
 	}
 
 	// Find closing delimiter.
@@ -65,17 +110,9 @@ static pair<string, string> ExtractFrontmatter(const string &content) {
 	size_t line_start = start;
 
 	while (line_start <= content.size()) {
-		if (line_start + 3 <= content.size()) {
-			string potential_delim = content.substr(line_start, 3);
-			if (potential_delim == "---" || potential_delim == "...") {
-				// Check that it's followed by newline or end of file or whitespace
-				if (line_start + 3 >= content.size() || content[line_start + 3] == '\n' ||
-				    content[line_start + 3] == '\r' || content[line_start + 3] == ' ' ||
-				    content[line_start + 3] == '\t') {
-					delim_start = line_start;
-					break;
-				}
-			}
+		if (IsDelimiterLine(content, line_start, /*allow_document_end=*/true)) {
+			delim_start = line_start;
+			break;
 		}
 		size_t newline_pos = content.find('\n', line_start);
 		if (newline_pos == string::npos) {
@@ -86,12 +123,22 @@ static pair<string, string> ExtractFrontmatter(const string &content) {
 
 	if (delim_start == string::npos) {
 		// No closing delimiter found - treat entire content as body
-		return {"", content};
+		return without_frontmatter();
 	}
 
-	// The frontmatter runs from `start` up to the newline preceding the delimiter line.
+	// The frontmatter runs from `start` up to the line break preceding the delimiter line.
+	// Trim that break explicitly rather than assuming a single '\n': under CRLF the byte
+	// before the delimiter is '\n' and the one before that is '\r', which would otherwise
+	// be left dangling on the last frontmatter line.
 	// When the delimiter is the first line of the block the frontmatter is empty.
-	string frontmatter = delim_start > start ? content.substr(start, (delim_start - 1) - start) : "";
+	size_t fm_end = delim_start;
+	if (fm_end > start && content[fm_end - 1] == '\n') {
+		fm_end--;
+	}
+	if (fm_end > start && content[fm_end - 1] == '\r') {
+		fm_end--;
+	}
+	string frontmatter = fm_end > start ? content.substr(start, fm_end - start) : "";
 
 	// Find start of body (after closing delimiter line)
 	size_t body_start = delim_start + 3; // skip ---

--- a/src/yaml_scalar_functions.cpp
+++ b/src/yaml_scalar_functions.cpp
@@ -72,7 +72,13 @@ void YAMLFunctions::RegisterValidationFunction(ExtensionLoader &loader) {
 static void YAMLToJSONFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	UnaryExecutor::Execute<string_t, string_t>(args.data[0], result, args.size(), [&](string_t yaml_str) -> string_t {
 		if (yaml_str.GetSize() == 0) {
-			return string_t();
+			// An empty YAML document is JSON `null` -- the same answer the
+			// docs.empty() branch below gives. This function is declared to return
+			// LogicalType::JSON(); a zero-length string is not JSON, and it was the
+			// value behind "Malformed JSON at byte 0 of input: input length is 0"
+			// from whichever json_* call touched the result next (#42). See the
+			// matching note in YAMLToJSONCast.
+			return StringVector::AddString(result, "null", 4);
 		}
 		yaml_utils::CheckInputSize(yaml_str.GetSize(), "yaml_to_json");
 

--- a/src/yaml_types.cpp
+++ b/src/yaml_types.cpp
@@ -31,7 +31,13 @@ static bool IsYAMLType(const LogicalType &t) {
 static bool YAMLToJSONCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
 	UnaryExecutor::Execute<string_t, string_t>(source, result, count, [&](string_t yaml_str) -> string_t {
 		if (yaml_str.GetSize() == 0) {
-			return string_t();
+			// An empty YAML document is JSON `null` -- which is what the docs.empty()
+			// branch below already answers. Returning string_t() handed a ZERO-LENGTH
+			// string back from a cast whose TARGET is LogicalType::JSON(), and a
+			// zero-length string is not JSON. Same defect as the swallowed parse
+			// error in VarcharToYAMLCast, by a route validating that cast does not
+			// close: `''::YAML` is a legal, reachable empty YAML value (#42).
+			return StringVector::AddString(result, "null", 4);
 		}
 
 		try {

--- a/src/yaml_types.cpp
+++ b/src/yaml_types.cpp
@@ -3,6 +3,7 @@
 #include "yaml_utils.hpp"
 #include "yaml_formatting.hpp"
 #include "yaml-cpp/yaml.h"
+#include "duckdb/common/operator/cast_operators.hpp"
 
 namespace duckdb {
 
@@ -88,25 +89,39 @@ static bool JSONToYAMLCast(Vector &source, Vector &result, idx_t count, CastPara
 }
 
 static bool VarcharToYAMLCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
-	UnaryExecutor::Execute<string_t, string_t>(source, result, count, [&](string_t str) -> string_t {
-		if (str.GetSize() == 0) {
-			return string_t();
-		}
+	bool success = true;
+	UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
+	    source, result, count, [&](string_t str, ValidityMask &mask, idx_t idx) -> string_t {
+		    if (str.GetSize() == 0) {
+			    return string_t();
+		    }
 
-		try {
-			// Try to parse as multi-document YAML first
-			auto docs = yaml_utils::ParseYAML(str.GetString(), true);
+		    try {
+			    // Try to parse as multi-document YAML first
+			    auto docs = yaml_utils::ParseYAML(str.GetString(), true);
 
-			// Format as block-style YAML
-			std::string yaml_str = yaml_utils::EmitYAMLMultiDoc(docs, yaml_utils::YAMLFormat::BLOCK);
-			return StringVector::AddString(result, yaml_str.c_str(), yaml_str.length());
-		} catch (...) {
-			// On parsing error, return empty string
-			return string_t();
-		}
-	});
+			    // Format as block-style YAML
+			    std::string yaml_str = yaml_utils::EmitYAMLMultiDoc(docs, yaml_utils::YAMLFormat::BLOCK);
+			    return StringVector::AddString(result, yaml_str.c_str(), yaml_str.length());
+		    } catch (const std::exception &e) {
+			    // ParseYAML() already raises a descriptive InvalidInputException, but this
+			    // used to swallow it and hand back an empty string. Unparseable input then
+			    // became an *empty YAML value* with no error anywhere: `'{unclosed: ['::YAML`
+			    // silently produced '', and yaml_to_json() of that returned an empty string
+			    // typed as JSON -- invalid JSON out of a function declared to return
+			    // LogicalType::JSON(), which only blew up much later and far away as
+			    // "Malformed JSON at byte 0 of input: input length is 0" (issue #42).
+			    //
+			    // Report it as a cast error instead: a plain CAST now raises, and TRY_CAST
+			    // yields NULL, which is what every other DuckDB type does.
+			    HandleCastError::AssignError(e.what(), parameters);
+			    mask.SetInvalid(idx);
+			    success = false;
+			    return string_t();
+		    }
+	    });
 
-	return true;
+	return success;
 }
 
 static bool YAMLToVarcharCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {

--- a/test/sql/yaml_frontmatter_delimiter.test
+++ b/test/sql/yaml_frontmatter_delimiter.test
@@ -1,0 +1,91 @@
+# name: test/sql/yaml_frontmatter_delimiter.test
+# description: The frontmatter open/close delimiters must be full-line matches, and a BOM must not hide frontmatter (#42)
+# group: [sql]
+
+require yaml
+
+# ---------------------------------------------------------------------------
+# Opening delimiter must be a complete "---" line.
+#
+# The opening test used to be a bare `content.substr(0, 3) == "---"` prefix match while
+# the closing test required a full-line match. A plain markdown file whose first line was
+# a thematic break (`----`) therefore "opened" a frontmatter block; everything up to the
+# next `---` line was swallowed as frontmatter (parsing to nothing) and only the tail came
+# back as the body. The document was silently truncated with no error.
+# ---------------------------------------------------------------------------
+
+# thematic_break.md has no frontmatter at all -- it opens with `----`. It must be skipped
+# entirely, exactly like any other frontmatter-less file. Before the fix this returned one
+# row whose content was just "\nMore text\n": the intro paragraph had been eaten.
+query I
+SELECT COUNT(*) FROM read_yaml_frontmatter('test/yaml/frontmatter_delimiters/thematic_break.md', as_yaml_objects:=true, content:=true);
+----
+0
+
+query I
+SELECT COUNT(*) FROM read_yaml_frontmatter('test/yaml/frontmatter_delimiters/thematic_break.md', as_yaml_objects:=false, content:=true);
+----
+0
+
+# `---foo` is not a delimiter line either. Before the fix this yielded a row with a NULL
+# frontmatter and a body of just "body\n"; `title: swallowed` vanished without a trace.
+query I
+SELECT COUNT(*) FROM read_yaml_frontmatter('test/yaml/frontmatter_delimiters/dash_prefix.md', as_yaml_objects:=true, content:=true);
+----
+0
+
+# ---------------------------------------------------------------------------
+# A UTF-8 BOM must not hide an otherwise valid frontmatter block.
+# Before the fix bom.md returned zero rows.
+# ---------------------------------------------------------------------------
+
+query III
+SELECT title, count, rtrim(content, chr(10)) FROM read_yaml_frontmatter('test/yaml/frontmatter_delimiters/bom.md', content:=true);
+----
+bom title	7	# Body after BOM
+
+# The BOM must not leak into the first key name either -- if it did, the column would be
+# named "﻿title" and this would resolve to NULL rather than TINYINT.
+query I
+SELECT typeof(count) FROM read_yaml_frontmatter('test/yaml/frontmatter_delimiters/bom.md');
+----
+TINYINT
+
+# ---------------------------------------------------------------------------
+# CRLF line endings: fields parse, and no stray '\r' is left dangling on the last
+# frontmatter line by the "delimiter minus one byte" slice.
+# ---------------------------------------------------------------------------
+
+query II
+SELECT title, count FROM read_yaml_frontmatter('test/yaml/frontmatter_delimiters/crlf.md');
+----
+crlf title	42
+
+query II
+SELECT title = 'crlf title', typeof(count) FROM read_yaml_frontmatter('test/yaml/frontmatter_delimiters/crlf.md');
+----
+true	TINYINT
+
+# ---------------------------------------------------------------------------
+# The empty-block fix from #50 must hold under CRLF and with a "..." closer too:
+# no body text may leak into the frontmatter.
+# ---------------------------------------------------------------------------
+
+query I
+SELECT COUNT(*) FROM read_yaml_frontmatter('test/yaml/frontmatter_delimiters/empty_block_crlf.md', as_yaml_objects:=true, content:=true);
+----
+0
+
+query I
+SELECT COUNT(*) FROM read_yaml_frontmatter('test/yaml/frontmatter_delimiters/empty_block_dots.md', as_yaml_objects:=true, content:=true);
+----
+0
+
+# ---------------------------------------------------------------------------
+# Regression: ordinary frontmatter still parses and the body is preserved intact.
+# ---------------------------------------------------------------------------
+
+query II
+SELECT title, content LIKE '%# My First Blog Post%' FROM read_yaml_frontmatter('test/yaml/frontmatter/post1.md', content:=true);
+----
+My First Blog Post	true

--- a/test/sql/yaml_invalid_cast.test
+++ b/test/sql/yaml_invalid_cast.test
@@ -67,3 +67,48 @@ query I
 SELECT ''::YAML::VARCHAR = '';
 ----
 true
+
+# The other half of the same defect, which the cast fix alone does not reach.
+#
+# The complaint in #42 is a function declared LogicalType::JSON() handing back
+# something that is not JSON. Validating the VARCHAR -> YAML cast closes the
+# route the issue described, but not the shape: `yaml_to_json` and the
+# YAML -> JSON cast both short-circuit a zero-length input to a zero-length
+# RESULT, and a zero-length string is not JSON. `''::YAML` is a legal, reachable
+# empty YAML value -- the assertion above says so deliberately -- so
+# `yaml_to_json(''::YAML)` still produced the same "Malformed JSON at byte 0 of
+# input: input length is 0" from whichever json_* call touched it next.
+#
+# An empty YAML document is JSON `null`, which is what the docs.empty() branch
+# one line further down already emitted.
+
+query I
+SELECT yaml_to_json(''::YAML)::VARCHAR;
+----
+null
+
+# SQL NULL is not the JSON literal null: it must still propagate as NULL.
+query I
+SELECT yaml_to_json(NULL::YAML) IS NULL;
+----
+true
+
+# The YAML -> JSON *cast* is a second copy of the same short-circuit and needed
+# the same fix. Naming the JSON type, and json_valid, both live in the json
+# extension -- everything above this line runs without it.
+require json
+
+query I
+SELECT (''::YAML::JSON)::VARCHAR;
+----
+null
+
+query II
+SELECT json_valid(yaml_to_json(''::YAML)::VARCHAR), json_valid((''::YAML::JSON)::VARCHAR);
+----
+true	true
+
+query I
+SELECT (NULL::YAML::JSON) IS NULL;
+----
+true

--- a/test/sql/yaml_invalid_cast.test
+++ b/test/sql/yaml_invalid_cast.test
@@ -1,0 +1,69 @@
+# name: test/sql/yaml_invalid_cast.test
+# description: Casting unparseable text to YAML must error, not silently yield an empty YAML value (#42)
+# group: [sql]
+
+require yaml
+
+# VarcharToYAMLCast used to wrap the whole parse in `catch (...) { return string_t(); }`.
+# ParseYAML() raises a descriptive error, but it was swallowed and the row became an
+# *empty* YAML value. Nothing anywhere reported a problem, and the damage surfaced later:
+# yaml_to_json() of that empty value returns an empty string typed as JSON, so a function
+# declared to return LogicalType::JSON() handed back something that is not JSON. The first
+# visible symptom was an unrelated-looking "Malformed JSON at byte 0 of input: input length
+# is 0" from whichever json_* call happened to touch it next.
+#
+# yaml_valid() always reported these correctly -- only the cast disagreed.
+
+query I
+SELECT yaml_valid('{unclosed: [');
+----
+false
+
+# A plain CAST now raises, like every other DuckDB type.
+statement error
+SELECT '{unclosed: ['::YAML;
+----
+Error parsing YAML
+
+# Tab indentation is invalid YAML too.
+statement error
+SELECT ('a:'||chr(10)||chr(9)||'b: 1')::YAML;
+----
+Error parsing YAML
+
+# The implicit cast on a VARCHAR literal argument goes through the same path, so a
+# yaml_to_json() that used to return a non-JSON empty string now errors instead.
+statement error
+SELECT yaml_to_json('{unclosed: [');
+----
+Error parsing YAML
+
+# TRY_CAST yields NULL rather than raising -- the standard DuckDB escape hatch.
+query I
+SELECT TRY_CAST('{unclosed: [' AS YAML) IS NULL;
+----
+true
+
+query II
+SELECT TRY_CAST('a: 1' AS YAML) IS NULL, TRY_CAST('{unclosed: [' AS YAML) IS NULL;
+----
+false	true
+
+# Valid documents are unaffected, including multi-line scalars and multi-document input.
+query I
+SELECT yaml_to_json('a: 1'::YAML)::VARCHAR;
+----
+{"a":1}
+
+query III
+SELECT yaml_to_json(('k: '||chr(34)||'a'||chr(10)||'b'||chr(34))::YAML)::VARCHAR,
+       yaml_to_json(('k: a'||chr(10)||'  b')::YAML)::VARCHAR,
+       yaml_to_json(('k: |'||chr(10)||'  a'||chr(10)||'  b')::YAML)::VARCHAR;
+----
+{"k":"a b"}	{"k":"a b"}	{"k":"a\nb"}
+
+# An empty string stays an empty YAML value (unchanged, and not a parse failure).
+query I
+SELECT ''::YAML::VARCHAR = '';
+----
+true

--- a/test/yaml/frontmatter_delimiters/bom.md
+++ b/test/yaml/frontmatter_delimiters/bom.md
@@ -1,0 +1,5 @@
+﻿---
+title: bom title
+count: 7
+---
+# Body after BOM

--- a/test/yaml/frontmatter_delimiters/crlf.md
+++ b/test/yaml/frontmatter_delimiters/crlf.md
@@ -1,0 +1,5 @@
+---
+title: crlf title
+count: 42
+---
+# Body after CRLF

--- a/test/yaml/frontmatter_delimiters/dash_prefix.md
+++ b/test/yaml/frontmatter_delimiters/dash_prefix.md
@@ -1,0 +1,4 @@
+---foo
+title: swallowed
+---
+body

--- a/test/yaml/frontmatter_delimiters/empty_block_crlf.md
+++ b/test/yaml/frontmatter_delimiters/empty_block_crlf.md
@@ -1,0 +1,7 @@
+---
+---
+Body line one.
+
+---
+
+leaked_field: nope

--- a/test/yaml/frontmatter_delimiters/empty_block_dots.md
+++ b/test/yaml/frontmatter_delimiters/empty_block_dots.md
@@ -1,0 +1,7 @@
+---
+...
+Body line one.
+
+---
+
+leaked_field: nope

--- a/test/yaml/frontmatter_delimiters/thematic_break.md
+++ b/test/yaml/frontmatter_delimiters/thematic_break.md
@@ -1,0 +1,8 @@
+----
+Some intro text that must survive.
+
+A paragraph.
+
+---
+
+More text


### PR DESCRIPTION
Two ways to lose data silently, found while verifying that #42's checkboxes were stale. Neither raises.

## 1. The opening delimiter was a prefix match

`----` opened a frontmatter block that **nothing could close** — the closing scan looks for an exact `---`, so it ran to the end of input. The document was silently truncated to whatever followed a later `---`, if one existed at all.

This is the mirror image of a bug found in `duckdb_markdown` at the same time (see its #55): there the *close* was the prefix match and the open was exact. Same fence, two codebases, opposite halves wrong.

Also fixed in the same area: **a BOM defeated frontmatter entirely**, returning zero rows.

## 2. `VarcharToYAMLCast` swallowed every parse failure

```cpp
catch (...) { return string_t(); }
```

Unparseable input became an **empty value typed as YAML**. That value then flows into functions declared `LogicalType::JSON()` and emits **invalid JSON** — so the second bullet of #42 is still true on `main`, by a much broader route than the one it describes. The umbrella framed it as a table-cell escaping issue; it is actually any invalid input reaching the cast.

## Verification

Full suite green: **1813 assertions across 53 cases**. New coverage: `yaml_frontmatter_delimiter.test`, `yaml_invalid_cast.test`, and six fixtures exercising BOM, CRLF, dash-prefix, dotted and thematic-break forms.

An earlier hypothesis for the cast bug was **built, observed not to change behaviour, and reverted** rather than shipped — the fix here is the one that was actually watched working.

## On issue #42 itself

Every remaining item is already-fixed, not-a-bug, or a feature request; each was re-checked against a current build rather than trusted from the checkbox. **#42 is closeable** — this PR addresses none of what it describes.

Cross-checked against markdown while here: `VarcharToMarkdownCast` is a pure passthrough with no parse step, so this class genuinely does not apply there. `MarkdownToHTMLCast` has the same empty-on-throw shape, but cmark has no "invalid markdown" to make it misbehave, so it was left alone rather than changed speculatively.
